### PR TITLE
Correctly increment timestamps by sample in SpikeDetect node

### DIFF
--- a/synapse/server/nodes/spike_detect.py
+++ b/synapse/server/nodes/spike_detect.py
@@ -102,7 +102,4 @@ class SpikeDetect(BaseNode):
 
                 # Advance the timestamp for the next bin
                 bin_duration_us = bin_size_in_samples * 1e6 / data.sample_rate
-                self.logger.info(
-                    f"Emitting spike train for bin of size {bin_duration_us}us"
-                )
                 self.buffer_start_ts += bin_duration_us


### PR DESCRIPTION
Previously, we were receiving buffers of broadband data in the spike binner node, and simply passing through the timestamp corresponding to the first broadband sample in the buffer, regardless of where we cut bins. This led to very jittery spike bin timestamps:

![before_timestamps](https://github.com/user-attachments/assets/a42d10b8-0d2e-4ea7-a65f-833f391a2d5c)

This PR fixes that:

![after_timestamps](https://github.com/user-attachments/assets/d70516fa-cd5f-4467-aac4-63386fa8a9de)
