### PR TITLE
fix: fix sequence number rollover in StreamOut, ElectricalBroadband chunk packet timestamping

### DIFF
--- a/synapse/server/nodes/stream_out.py
+++ b/synapse/server/nodes/stream_out.py
@@ -92,8 +92,8 @@ class StreamOut(BaseNode):
         packets = []
 
         try:
-            packets = data.pack(self.__sequence_number)
-            self.__sequence_number += len(packets)
+            packets, seq = data.pack(self.__sequence_number)
+            self.__sequence_number = seq
         except Exception as e:
             raise ValueError(f"Error packing data: {e}")
 

--- a/synapse/tests/test_stream_out.py
+++ b/synapse/tests/test_stream_out.py
@@ -14,6 +14,8 @@ from synapse.utils.ndtp_types import (
 def test_packing_broadband_data():
     node = StreamOut(id=1)
 
+    assert node.__sequence_number == 0
+
     # Signed
     sample_data = [
         (1, np.array([-1000, 2000, 1000], dtype=np.int16)),
@@ -29,6 +31,8 @@ def test_packing_broadband_data():
     )
 
     packed = node._pack(bdata)
+
+    assert node.__sequence_number == 1
 
     for i, p in enumerate(packed):
         unpacked = NDTPMessage.unpack(p)
@@ -58,23 +62,24 @@ def test_packing_broadband_data():
 
     packed = node._pack(bdata)
 
+    assert node.__sequence_number == 2
+
     for i, p in enumerate(packed):
         unpacked = NDTPMessage.unpack(p)
 
 
 def test_packing_broadband_data():
     node = StreamOut(id=1)
-    seq = 0
+    assert node._StreamOut__sequence_number == 0
 
     n_samples = 10000
+    bit_width = 16
 
     sample_data = [
         (1, np.array([i for i in range(n_samples)], dtype=np.int16)),
-        (2, np.array([i for i in range(n_samples)], dtype=np.int16)),
-        (3, np.array([i for i in range(n_samples)], dtype=np.int16)),
     ]
     bdata = ElectricalBroadbandData(
-        bit_width=16,
+        bit_width=bit_width,
         sample_rate=36000,
         t0=1234567890,
         samples=sample_data,
@@ -83,56 +88,61 @@ def test_packing_broadband_data():
 
     packed = node._pack(bdata)
     seq = 0
-    for c in range(3):
-        ch_data = sample_data[c]
-        chunks = chunk_channel_data(ch_data[1], MAX_CH_PAYLOAD_SIZE_BYTES)
+    n_samples = 0
+    ch_data = sample_data[0]
+    chunks = chunk_channel_data(bit_width, ch_data[1], MAX_CH_PAYLOAD_SIZE_BYTES)
 
-        for chunk in chunks:
-            p = packed[seq]
-            unpacked = NDTPMessage.unpack(p)
-            assert unpacked.header.timestamp == bdata.t0
-            assert unpacked.header.seq_number == seq
+    for chunk in chunks:
+        t_chunk = bdata.t0 + round(n_samples * 1e6 / bdata.sample_rate)
 
-            assert unpacked.payload.bit_width == 16
-            assert unpacked.payload.sample_rate == bdata.sample_rate
-            assert unpacked.payload.is_signed == bdata.is_signed
-            assert unpacked.payload.channels[0].channel_id == ch_data[0]
-            assert list(unpacked.payload.channels[0].channel_data) == list(chunk)
+        p = packed[seq]
+        unpacked = NDTPMessage.unpack(p)
+        assert unpacked.header.timestamp == t_chunk
+        assert unpacked.header.seq_number == seq
 
-            seq += 1
+        assert unpacked.payload.bit_width == bit_width
+        assert unpacked.payload.sample_rate == bdata.sample_rate
+        assert unpacked.payload.is_signed == bdata.is_signed
+        assert unpacked.payload.channels[0].channel_id == ch_data[0]
+        assert list(unpacked.payload.channels[0].channel_data) == list(chunk)
+
+        n_samples += len(chunk)
+        if chunk is list(chunks)[-1]:  # If this is the last chunk for this channel
+            n_samples = j
+        seq += 1
 
     sample_data = [
         (1, np.array([i for i in range(n_samples)], dtype=np.uint16)),
-        (2, np.array([i for i in range(n_samples)], dtype=np.uint16)),
-        (3, np.array([i for i in range(n_samples)], dtype=np.uint16)),
     ]
     bdata = ElectricalBroadbandData(
-        bit_width=16,
+        bit_width=bit_width,
         sample_rate=36000,
         t0=1234567890,
         samples=sample_data,
     )
 
+    node = StreamOut(id=1)
+    assert node._StreamOut__sequence_number == 0
+
     packed = node._pack(bdata)
-    seq2 = 0
-    for c in range(3):
-        ch_data = sample_data[c]
-        chunks = chunk_channel_data(ch_data[1], MAX_CH_PAYLOAD_SIZE_BYTES)
+    seq = 0
+    ch_data = sample_data[0]
+    chunks = chunk_channel_data(bit_width, ch_data[1], MAX_CH_PAYLOAD_SIZE_BYTES)
 
-        for chunk in chunks:
-            p = packed[seq2]
-            unpacked = NDTPMessage.unpack(p)
+    for chunk in chunks:
+        p = packed[seq]
+        unpacked = NDTPMessage.unpack(p)
 
-            assert unpacked.header.timestamp == bdata.t0
-            assert unpacked.header.seq_number == seq + seq2
+        assert unpacked.header.timestamp == bdata.t0
+        assert unpacked.header.seq_number == seq
 
-            assert unpacked.payload.bit_width == 16
-            assert unpacked.payload.sample_rate == bdata.sample_rate
-            assert unpacked.payload.is_signed == bdata.is_signed
-            assert unpacked.payload.channels[0].channel_id == ch_data[0]
-            assert list(unpacked.payload.channels[0].channel_data) == list(chunk)
+        assert unpacked.payload.bit_width == 16
+        assert unpacked.payload.sample_rate == bdata.sample_rate
+        assert unpacked.payload.is_signed == bdata.is_signed
+        assert unpacked.payload.channels[0].channel_id == ch_data[0]
+        assert list(unpacked.payload.channels[0].channel_data) == list(chunk)
 
-            seq2 += 1
+        seq += 1
 
 
 def test_packing_spiketrain_data():


### PR DESCRIPTION
Fixes
- NDTP msg sequence numbers in python not rolling over correctly (python can store seq_number > 2^16-1, but a value that big will overflow when packed into the NDTP header). With this change, the message pack() utils will roll the sequence number over as well
- Subsequent chunked ElectricalBroadband packets always had the same t0, which was only correct for the first chunk. Now new timestamps are calculated for the subsequent chunks based on t0, the sample rate and cumulative number of samples 