### PR TITLE
Increase Stream Out recieve buffer size to decrease packet loss

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.csv
+*.dat
 # Generated protobuf code
 synapse/api/
 bin/

--- a/README.md
+++ b/README.md
@@ -52,6 +52,45 @@ And a toy device `synapse-sim` for local development,
     --serial SERIAL       Device serial number
     -v, --verbose         Enable verbose output
 
+## A Note on Streaming
+Synapse devices stream data to and from clients with UDP. To minimize packet loss, it is highly recommended that users increase their OS UDP buffer size. 
+### On Linux
+Check the current UDP buffer size with:
+```
+% sysctl net.core.rmem_max # Recieve buffer
+% sysctl net.core.wmem_max # Send buffer
+```  
+
+To update the buffer size immediately:
+```
+% sudo sysctl -w net.core.rmem_max=10485760 # 10 MB
+% sudo sysctl -w net.core.wmem_max=10485760 # 10 MB
+```
+
+Or make a persistent change by adding the following file:
+```
+% sudo touch /etc/sysctl.d/50-udp-buffersize.conf
+# And add these lines:
+net.core.rmem_max=10485760
+net.core.wmem_max=10485760
+```
+then reboot for the changes to take effect. 
+
+### On MacOS
+Check the current UDP buffer size:
+```
+% sysctl kern.ipc.maxsockbuf
+```
+
+To update the buffer size immediately:
+```
+sudo sysctl -w kern.ipc.maxsockbuf=10485760
+```
+or add the following to `/etc/sysctl.conf`:
+```
+kern.ipc.maxsockbuf=10485760
+```
+
 ## Writing clients
 
 This library offers an idiomatic Python interpretation of the Synapse API:

--- a/synapse/client/nodes/stream_out.py
+++ b/synapse/client/nodes/stream_out.py
@@ -71,6 +71,13 @@ class StreamOut(Node):
         self.__socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         self.__socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
 
+        SOCKET_BUFSIZE_BYTES = 5 * 1024 * 1024 # 5MB
+        self.__socket.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, SOCKET_BUFSIZE_BYTES)
+        recvbuf = self.__socket.getsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF)
+
+        if recvbuf < SOCKET_BUFSIZE_BYTES:
+            logging.warning(f"Could not set socket buffer size to {SOCKET_BUFSIZE_BYTES}. Current size is {recvbuf}. Consider increasing the system limit.")
+
         logging.info(f"binding to {addr}:{port}")
         self.__socket.bind((addr, port))
 


### PR DESCRIPTION
Increases the socket buffer size on the StreamOut Node. I've set it to 5MB currently since that is ~200ms worth of buffering at 200Mbit/sec which should be plenty for our current systems. The default OS UDP receive buffer size is normally much smaller than 5MB and needs to be adjusted manually by the user. 

Also sequence number counting to take into account overflow of the sequence number.