### PR TITLE
fix: increase spiketrain payload bit width to 4

### DIFF
--- a/synapse/tests/test_ndtp.py
+++ b/synapse/tests/test_ndtp.py
@@ -285,10 +285,48 @@ def test_ndtp_payload_broadband_large():
     
 
 def test_ndtp_payload_spiketrain():
-    samples = [0, 1, 2, 3, 2]
+    samples = [0, 1, 2, 3, 4, 5, 6]
 
     payload = NDTPPayloadSpiketrain(10, samples)
     packed = payload.pack()
+    hexstring = " ".join(f"{i:02x}" for i in packed)
+    print(hexstring)
+
+    assert packed[0] == 0
+    assert packed[1] == 0
+    assert packed[2] == 0
+    assert packed[3] == 7
+    assert packed[4] == 10
+
+    # 0000 0001 0010 0011 0100 0101 0110 0000
+    assert packed[5] == 1
+    assert packed[6] == 35
+    assert packed[7] == 69
+    assert packed[8] == 96
+
+
+    unpacked = NDTPPayloadSpiketrain.unpack(packed)
+
+    assert unpacked == payload
+    assert unpacked.bin_size_ms == 10
+    assert list(unpacked.spike_counts) == samples
+
+    print("2s")
+    samples = [2, 2, 2, 2, 2, 2, 2, 2, 2, 2]
+
+    payload = NDTPPayloadSpiketrain(10, samples)
+    packed = payload.pack()
+    hexstring = " ".join(f"{i:02x}" for i in packed)
+    print(hexstring)
+
+    assert packed[3] == 10
+    assert packed[4] == 10
+    assert packed[5] == 34
+    assert packed[6] == 34
+    assert packed[7] == 34
+    assert packed[8] == 34
+    assert packed[8] == 34
+
     unpacked = NDTPPayloadSpiketrain.unpack(packed)
 
     assert unpacked == payload
@@ -313,7 +351,6 @@ def test_ndtp_header():
             + struct.pack(">B", DataType.kBroadband)
             + struct.pack(">Q", 123)
         )
-
 
 def test_ndtp_message_broadband():
     header = NDTPHeader(DataType.kBroadband, timestamp=1234567890, seq_number=42)

--- a/synapse/tests/test_stream_out.py
+++ b/synapse/tests/test_stream_out.py
@@ -151,7 +151,7 @@ def test_packing_spiketrain_data():
     sdata = SpiketrainData(
         t0=1234567890,
         bin_size_ms=10,
-        spike_counts=[0, 1, 2, 3, 2, 1, 0],
+        spike_counts=[0, 1, 2, 3, 4, 5, 6],
     )
 
     packed = node._pack(sdata)[0]

--- a/synapse/utils/ndtp.pyx
+++ b/synapse/utils/ndtp.pyx
@@ -17,7 +17,7 @@ cdef int DATA_TYPE_K_BROADBAND = DataType.kBroadband
 cdef int DATA_TYPE_K_SPIKETRAIN = DataType.kSpiketrain
 
 NDTP_VERSION = 0x01
-cdef int NDTPPayloadSpiketrain_BIT_WIDTH = 2
+cdef int NDTPPayloadSpiketrain_BIT_WIDTH = 4
 
 CRC_16 = crcmod.predefined.mkCrcFun('crc-16')
 


### PR DESCRIPTION
bump NDTPPayloadSpiketrain_BIT_WIDTH to 4 in line with ndtp.h value for similar named struct in libndtp repo. [libndtp repo reference here](https://github.com/sciencecorp/libndtp/blob/5e0f16dc4f1ae96f409f4acc627b39588f61223b/include/science/libndtp/ndtp.h#L124).