### PR TITLE
Initial impl of beacon-based autodiscovery

### DIFF
--- a/synapse/cli/discover.py
+++ b/synapse/cli/discover.py
@@ -1,9 +1,5 @@
 from synapse.utils.discover import discover as _discover
 
-BROADCAST_PORT = 6470
-BROADCAST_ADDR = "224.0.0.245"
-
-
 def add_commands(subparsers):
     a = subparsers.add_parser(
         "discover", help="Discover Synapse devices on the network"

--- a/synapse/server/autodiscovery.py
+++ b/synapse/server/autodiscovery.py
@@ -1,3 +1,4 @@
+import asyncio
 class MulticastDiscoveryProtocol:
     def __init__(
         self, server_name, serial, rpc_port=647
@@ -26,3 +27,31 @@ class MulticastDiscoveryProtocol:
             )
         else:
             print("Unknown command: {!r}".format(command))
+
+
+class BroadcastDiscoveryProtocol:
+    def __init__(self, discovery_port, server_name, serial, rpc_port=647, broadcast_interval=1):
+        self.server_name = server_name
+        self.serial = serial
+        self.rpc_port = rpc_port
+        self.broadcast_interval = broadcast_interval
+        self.discovery_port = discovery_port
+
+    def connection_made(self, transport):
+        self.transport = transport
+        asyncio.create_task(self.broadcast_loop())
+
+    async def broadcast_loop(self):
+        while True:
+            self.broadcast_message()
+            await asyncio.sleep(self.broadcast_interval)
+
+    def broadcast_message(self):
+        message = "ID {} SYN1.0 {} {}".format(self.serial, self.rpc_port, self.server_name).encode("ascii")
+        self.transport.sendto(message, ('255.255.255.255', self.discovery_port))
+
+    def datagram_received(self, data, addr):
+        pass
+
+    def connection_lost(self, exc):
+        pass


### PR DESCRIPTION
This changes the autodiscovery system to a broadcast-beacon based protocol rather than a multicast based protocol. The aim of this was to improve reliability on networks that dont support multicast, and hopefully improve the reliability of device discovery.

Switching to a UDP-broadcast based system comes with the caveat that it may place unnecessary strain on a network if a large number of SciFis are connected. However for current use-cases broadcast shouldn't be causing meaningful network congestion. 

# Testing
Tested using a corresponding server implementation [here](https://github.com/sciencecorp/headstage/pull/145)

I tested that the autodiscovery remains working when:
- autodiscovery starts before the device is connected to a network
- the device disconnects from a network while autodiscovery is running
- the device disconnects from one network and reconnects to a different network
- the device is turned on and immediately connects to a network
- the device turns on and does not find a network, then later the network comes online
