### PR TITLE
Fix bug in reading spike detect and filter node from proto.

### DIFF
--- a/synapse/cli/rpc.py
+++ b/synapse/cli/rpc.py
@@ -99,8 +99,7 @@ def configure(args):
     with open(args.config_file) as config_json:
         config_proto = Parse(config_json.read(), DeviceConfiguration())
         print("Configuring device with the following configuration:")
-        print(config_proto)
+        config = syn.Config.from_proto(config_proto)
+        print(config.to_proto())
 
-        return syn.Device(args.uri, args.verbose).configure(
-            syn.Config.from_proto(config_proto)
-        )
+        return syn.Device(args.uri, args.verbose).configure(config)

--- a/synapse/client/config.py
+++ b/synapse/client/config.py
@@ -56,6 +56,7 @@ class Config(object):
 
         for n in proto.nodes:
             if n.type not in list(NODE_TYPE_OBJECT_MAP.keys()):
+                print(f"Unknown node type: {n.type}")
                 continue
             node = NODE_TYPE_OBJECT_MAP[n.type].from_proto(n)
 

--- a/synapse/client/nodes/spectral_filter.py
+++ b/synapse/client/nodes/spectral_filter.py
@@ -34,7 +34,3 @@ class SpectralFilter(Node):
             proto.low_cutoff_hz,
             proto.high_cutoff_hz,
         )
-
-    @staticmethod
-    def from_proto(proto):
-        return SpectralFilter._from_proto(proto.spectral_filter)

--- a/synapse/client/nodes/spike_detect.py
+++ b/synapse/client/nodes/spike_detect.py
@@ -47,7 +47,3 @@ class SpikeDetect(Node):
             sort=proto.sort,
             bin_size_ms=proto.bin_size_ms,
         )
-
-    @staticmethod
-    def from_proto(proto):
-        return SpikeDetect._from_proto(proto.spike_detect)


### PR DESCRIPTION
The dangling `from_proto()` call in the spike detect and spectral filter node causes configs to be improperly read. They seem to have missed the switchover to exclusively using `_from_proto()`. 