### PR TITLE
feat: switch timestamps (sim BroadbandSource) to nanoseconds

### DIFF
--- a/synapse/server/nodes/stream_out.py
+++ b/synapse/server/nodes/stream_out.py
@@ -80,6 +80,8 @@ class StreamOut(BaseNode):
             data = await self.data_queue.get()
             packets = self._pack(data)
 
+            self.logger.debug(f"sending {len(packets)} packets")
+
             for packet in packets:
                 await loop.run_in_executor(
                     None,

--- a/synapse/server/nodes/stream_out.py
+++ b/synapse/server/nodes/stream_out.py
@@ -80,8 +80,6 @@ class StreamOut(BaseNode):
             data = await self.data_queue.get()
             packets = self._pack(data)
 
-            self.logger.debug(f"sending {len(packets)} packets")
-
             for packet in packets:
                 await loop.run_in_executor(
                     None,

--- a/synapse/simulator/nodes/broadband_source.py
+++ b/synapse/simulator/nodes/broadband_source.py
@@ -53,24 +53,23 @@ class BroadbandSource(BaseNode):
         bit_width = c.bit_width if c.bit_width else 4
         sample_rate_hz = c.sample_rate_hz if c.sample_rate_hz else 16000
 
-        t0 = time.time_ns()
+        t_last_ns = time.time_ns()
         while self.running:
+            await asyncio.sleep(0.01)
+            
             now = time.time_ns()
-            elapsed_ns = now - t0
+            elapsed_ns = now - t_last_ns
             n_samples = int(sample_rate_hz * elapsed_ns / 1e9)
+            
             samples = [[ch.id, [r_sample(bit_width) for _ in range(n_samples)]] for ch in channels]
 
             data = ElectricalBroadbandData(
                 bit_width=bit_width,
                 is_signed=False,
                 sample_rate=sample_rate_hz,
-                t0=t0,
+                t0=t_last_ns,
                 samples=samples
             )
 
-            self.logger.debug(f"[{t0}] sending {n_samples} samples")
             await self.emit_data(data)
-
-            t0 = now
-
-            await asyncio.sleep(0.100)
+            t_last_ns = now

--- a/synapse/simulator/nodes/broadband_source.py
+++ b/synapse/simulator/nodes/broadband_source.py
@@ -53,20 +53,22 @@ class BroadbandSource(BaseNode):
         bit_width = c.bit_width if c.bit_width else 4
         sample_rate_hz = c.sample_rate_hz if c.sample_rate_hz else 16000
 
-        t0 = time.time_ns() // 1000
+        t0 = time.time_ns()
         while self.running:
-            now = time.time_ns() // 1000
-            elapsed = now - t0
-            n_samples = int(sample_rate_hz * elapsed / 1e6)
+            now = time.time_ns()
+            elapsed_ns = now - t0
+            n_samples = int(sample_rate_hz * elapsed_ns / 1e9)
+            samples = [[ch.id, [r_sample(bit_width) for _ in range(n_samples)]] for ch in channels]
 
             data = ElectricalBroadbandData(
                 bit_width=bit_width,
                 is_signed=False,
                 sample_rate=sample_rate_hz,
                 t0=t0,
-                samples=[[ch.id, [r_sample(bit_width) for _ in range(n_samples)]] for ch in channels]
+                samples=samples
             )
 
+            self.logger.debug(f"[{t0}] sending {n_samples} samples")
             await self.emit_data(data)
 
             t0 = now

--- a/synapse/simulator/nodes/spike_source.py
+++ b/synapse/simulator/nodes/spike_source.py
@@ -56,9 +56,9 @@ class SpikeSource(BaseNode):
         min_spikes = max(0, int(1 * window_s))
         max_spikes = min(15, int(200 * window_s))
 
-        t0 = time.time_ns() // 1000
+        t0 = time.time_ns()
         while self.running:
-            now = time.time_ns() // 1000       
+            now = time.time_ns()
 
             spike_counts = [random.randint(min_spikes, max_spikes) for _ in channels]
             data = SpiketrainData(
@@ -67,7 +67,6 @@ class SpikeSource(BaseNode):
                 spike_counts=spike_counts
             )
             
-
             await self.emit_data(data)
 
             t0 = now

--- a/synapse/utils/ndtp_types.py
+++ b/synapse/utils/ndtp_types.py
@@ -24,11 +24,21 @@ def chunk_channel_data(bit_width: int, ch_data: List[float], max_payload_size_by
         yield ch_data[start_idx:end_idx]
 
 class ElectricalBroadbandData:
+    """Electrical broadband data from neural recordings.
+
+    Attributes:
+        t0 (int): Start timestamp in nanoseconds
+        is_signed (bool): Whether the data is represented using signed integers
+        bit_width (int): Number of bits used to represent each sample
+        samples (Tuple[int, List[float]]): Tuple of (channel_id, data_samples)
+        sample_rate (float): Sample rate in Hz
+    """
     __slots__ = ["data_type", "t0", "is_signed", "bit_width", "samples", "sample_rate"]
 
     def __init__(self, t0, bit_width, samples: Tuple[int, List[float]], sample_rate, is_signed=True):
         self.data_type = DataType.kBroadband
-        self.t0 = t0
+
+        self.t0 = t0 # ns
         self.is_signed = is_signed
         self.bit_width = bit_width
         self.samples = samples
@@ -104,13 +114,19 @@ class ElectricalBroadbandData:
             ],
         ]
 
-
 class SpiketrainData:
+    """Binned spike train data from neural recordings.
+
+    Attributes:
+        t0 (int): Start timestamp in nanoseconds
+        bin_size_ms (float): Size of each time bin in milliseconds
+        spike_counts (List[int]): Number of spikes in each time bin
+    """
     __slots__ = ["data_type", "t0", "bin_size_ms", "spike_counts"]
 
     def __init__(self, t0, bin_size_ms, spike_counts):
         self.data_type = DataType.kSpiketrain
-        self.t0 = t0
+        self.t0 = t0 # ns
         self.bin_size_ms = bin_size_ms
         self.spike_counts = spike_counts
 


### PR DESCRIPTION
BREAKING CHANGE: switch generated timestamps from us to ns

---

On the topic, `ElectricalBroadbandData` should probably become `BroadbandData`; and we might as well add units to all fields where applicable, if we're going to have breaking changes