### PR TITLE
More consistent logging of rpc errors

### DIFF
--- a/synapse/cli/rpc.py
+++ b/synapse/cli/rpc.py
@@ -72,10 +72,17 @@ def query(args):
                         f.write(
                             f"{measurement.electrode_id},{measurement.magnitude},{measurement.phase},1\n"
                         )
-
-
 def start(args):
-    return syn.Device(args.uri, args.verbose).start()
+    console = Console()
+    with console.status("Starting device...", spinner="bouncingBall"):
+        stop_ret = syn.Device(args.uri, args.verbose).start_with_status()
+        if not stop_ret:
+            console.print("[bold red]Internal error starting device")
+            return
+        if stop_ret.code != StatusCode.kOk:
+            console.print(f"[bold red]Error starting\n{stop_ret.message}")
+            return
+    console.print("[green]Device Started")
 
 
 def stop(args):
@@ -97,9 +104,17 @@ def configure(args):
         return False
 
     with open(args.config_file) as config_json:
+        console = Console()
         config_proto = Parse(config_json.read(), DeviceConfiguration())
-        print("Configuring device with the following configuration:")
+        console.print("Configuring device with the following configuration:")
         config = syn.Config.from_proto(config_proto)
-        print(config.to_proto())
+        console.print(config.to_proto())
 
-        return syn.Device(args.uri, args.verbose).configure(config)
+        config_ret = syn.Device(args.uri, args.verbose).configure_with_status(config)
+        if not config_ret:
+            console.print("[bold red]Internal error configuring device")
+            return
+        if config_ret.code != StatusCode.kOk:
+            console.print(f"[bold red]Error configuring\n{config_ret.message}")
+            return
+        console.print("[green]Device Configured")

--- a/synapse/cli/rpc.py
+++ b/synapse/cli/rpc.py
@@ -72,6 +72,7 @@ def query(args):
                         f.write(
                             f"{measurement.electrode_id},{measurement.magnitude},{measurement.phase},1\n"
                         )
+
 def start(args):
     console = Console()
     with console.status("Starting device...", spinner="bouncingBall"):

--- a/synapse/client/device.py
+++ b/synapse/client/device.py
@@ -39,7 +39,7 @@ class Device(object):
             response = self.rpc.Start(Empty())
             return response
         except grpc.RpcError as e:
-            self.logger.debug("Error: %s", e.details())
+            self.logger.error("Error: %s", e.details())
         return None
 
     def stop(self):
@@ -48,14 +48,14 @@ class Device(object):
             if self._handle_status_response(response):
                 return response
         except grpc.RpcError as e:
-            self.logger.debug("Error: %s", e.details())
+            self.logger.error("Error: %s", e.details())
         return False
 
     def stop_with_status(self) -> Status:
         try:
             return self.rpc.Stop(Empty())
         except grpc.RpcError as e:
-            self.logger.debug("Error: %s", e.details())
+            self.logger.error("Error: %s", e.details())
             return None
 
     def info(self):
@@ -64,7 +64,7 @@ class Device(object):
             self._handle_status_response(response.status)
             return response
         except grpc.RpcError as e:
-            self.logger.debug("Error: %s", e.details())
+            self.logger.error("Error: %s", e.details())
             return None
 
     def query(self, query):
@@ -72,7 +72,7 @@ class Device(object):
             response = self.rpc.Query(query)
             return response
         except grpc.RpcError as e:
-            self.logger.debug("Error: %s", e.details())
+            self.logger.error("Error: %s", e.details())
             return None
 
     def configure(self, config: Config):
@@ -84,7 +84,7 @@ class Device(object):
             if self._handle_status_response(response):
                 return response
         except grpc.RpcError as e:
-            self.logger.debug("Error: %s", e.details())
+            self.logger.error("Error: %s", e.details())
         return False
     
     def configure_with_status(self, config: Config) -> Status:
@@ -95,7 +95,7 @@ class Device(object):
             response = self.rpc.Configure(config.to_proto())
             return response
         except grpc.RpcError as e:
-            self.logger.debug("Error: %s", e.details())
+            self.logger.error("Error: %s", e.details())
             return None
 
     def _handle_status_response(self, status):


### PR DESCRIPTION
Ive built out the logging for start/stop/configure calls so we get the same pretty printing as with the stop command. 