### PR TITLE
fix: bump protobuf usage to latest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-coolname==2.2.0
-grpcio==1.64.1
-grpcio-tools==1.62.2
-protoletariat==3.2.19
+coolname
+grpcio
+grpcio-tools
+protoletariat
 pyserial
 pyzmq
 build
@@ -14,4 +14,7 @@ pytest-asyncio
 dearpygui
 pyqtgraph
 pyqt5
-pandas
+pandas>=2.2.0
+protobuf>=5.29
+numpy >=2.0.0
+crcmod

--- a/synapse/cli/streaming.py
+++ b/synapse/cli/streaming.py
@@ -203,7 +203,7 @@ def read(args):
         return
     runtime_config = device_info_after_config.configuration
     runtime_config_json = MessageToJson(
-        runtime_config, including_default_value_fields=True
+        runtime_config, always_print_fields_with_no_presence=True
     )
     output_config_path = os.path.join(output_base, "runtime_config.json")
     with open(output_config_path, "w") as f:
@@ -351,9 +351,7 @@ def _binary_writer(stop, q, num_ch, output_base):
                     for frame in frames:
                         for sample in frame:
                             fd.write(
-                                int(sample).to_bytes(
-                                    2, byteorder="little", signed=True
-                                )
+                                int(sample).to_bytes(2, byteorder="little", signed=True)
                             )
 
         except Exception as e:


### PR DESCRIPTION
# Summary
We didn't sync our pip setup.py and our requirements, resulting in diverging protobuf dependencies. 

This manifested as:
```
Traceback (most recent call last):
  File "/home/gilbert/workspace/wip/science-python-temp/.venv/bin/synapsectl", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/gilbert/workspace/wip/science-python-temp/.venv/lib/python3.12/site-packages/synapse/cli/__main__.py", line 42, in main
    args.func(args)
  File "/home/gilbert/workspace/wip/science-python-temp/.venv/lib/python3.12/site-packages/synapse/cli/streaming.py", line 210, in read
    runtime_config_json = MessageToJson(
                          ^^^^^^^^^^^^^^
TypeError: MessageToJson() got an unexpected keyword argument 'including_default_value_fields'
```

# Testing
  * Tested locally, could stream