### PR TITLE
feature: upgrade to use udp unicast

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,12 @@ And a toy device `synapse-sim` for local development,
 
     options:
     -h, --help            show this help message and exit
-    --iface-ip IFACE_IP   IP of the network interface to use for multicast traffic
+    --iface-ip IFACE_IP   IP of the network interface to use for streaming data
     --rpc-port RPC_PORT   Port to listen for RPC requests
     --discovery-port DISCOVERY_PORT
                             Port to listen for discovery requests
     --discovery-addr DISCOVERY_ADDR
-                            Multicast address to listen for discovery requests
+                            UDP address to listen for discovery requests
     --name NAME           Device name
     --serial SERIAL       Device serial number
     -v, --verbose         Enable verbose output

--- a/synapse/cli/__main__.py
+++ b/synapse/cli/__main__.py
@@ -3,10 +3,11 @@ import argparse
 import logging
 from importlib import metadata
 from synapse.cli import discover, rpc, streaming, offline_plot, files
+from rich.logging import RichHandler
 
 
 def main():
-    logging.basicConfig(level=logging.INFO)
+    logging.basicConfig(level=logging.INFO, handlers=[RichHandler()])
 
     parser = argparse.ArgumentParser(
         description="Synapse Device Manager",

--- a/synapse/cli/streaming.py
+++ b/synapse/cli/streaming.py
@@ -229,6 +229,7 @@ def read(args):
     if args.plot:
         threads.append(
             threading.Thread(target=_plot_data, args=(stop, plot_q, runtime_config))
+        )
 
     for thread in threads:
         thread.start()

--- a/synapse/cli/streaming.py
+++ b/synapse/cli/streaming.py
@@ -17,8 +17,10 @@ import synapse as syn
 import synapse.client.channel as channel
 import synapse.utils.ndtp_types as ndtp_types
 import synapse.cli.synapse_plotter as plotter
+from synapse.utils.packet_monitor import PacketMonitor
 
 from rich.console import Console
+from rich.live import Live
 from rich.pretty import pprint
 
 
@@ -76,9 +78,7 @@ def read(args):
             return
         else:
             console.print(f"[bold yellow]Overwriting existing files in {output_base}")
-
     device = syn.Device(args.uri, args.verbose)
-
     with console.status(
         "Reading from Synapse Device", spinner="bouncingBall", spinner_style="green"
     ) as status:
@@ -210,47 +210,44 @@ def read(args):
         if args.duration
         else "Streaming data indefinitely"
     )
-    with console.status(
-        status_title, spinner="bouncingBall", spinner_style="green"
-    ) as status:
-        q = queue.Queue()
-        plot_q = queue.Queue() if args.plot else None
+    console.print(status_title)
 
-        threads = []
-        stop = threading.Event()
-        if args.bin:
-            threads.append(
-                threading.Thread(
-                    target=_binary_writer, args=(stop, q, num_ch, output_base)
-                )
-            )
-        else:
-            threads.append(
-                threading.Thread(target=_data_writer, args=(stop, q, output_base))
-            )
+    q = queue.Queue()
+    plot_q = queue.Queue() if args.plot else None
 
-        if args.plot:
-            threads.append(
-                threading.Thread(target=_plot_data, args=(stop, plot_q, runtime_config))
-            )
+    threads = []
+    stop = threading.Event()
+    if args.bin:
+        threads.append(
+            threading.Thread(target=_binary_writer, args=(stop, q, num_ch, output_base))
+        )
+    else:
+        threads.append(
+            threading.Thread(target=_data_writer, args=(stop, q, output_base))
+        )
+
+    if args.plot:
+        threads.append(
+            threading.Thread(target=_plot_data, args=(stop, plot_q, runtime_config))
+
+    for thread in threads:
+        thread.start()
+
+    try:
+        read_packets(stream_out, q, plot_q, stop, args.duration)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        console.print("Stopping read...")
+        stop.set()
         for thread in threads:
-            thread.start()
+            thread.join()
 
-        try:
-            read_packets(stream_out, q, plot_q, args.duration)
-        except KeyboardInterrupt:
-            pass
-        finally:
-            print("Stopping read...")
-            stop.set()
-            for thread in threads:
-                thread.join()
-
-            if args.config:
-                console.print("Stopping device...")
-                if not device.stop():
-                    console.print("[red]Failed to stop device")
-                console.print("Stopped")
+        if args.config:
+            console.print("Stopping device...")
+            if not device.stop():
+                console.print("[red]Failed to stop device")
+            console.print("Stopped")
 
     console.print("[bold green]Streaming complete")
     console.print("[cyan]================")
@@ -266,56 +263,38 @@ def read_packets(
     node: syn.StreamOut,
     q: queue.Queue,
     plot_q: queue.Queue,
+    stop,
     duration: Optional[int] = None,
     num_ch: int = 32,
 ):
-    packet_count = 0
-    seq_number = None
-    dropped_packets = 0
     start = time.time()
-    print_interval = 1000
 
-    print(
-        f"Reading packets for duration {duration} seconds"
-        if duration
-        else "Reading packets..."
-    )
+    # Keep track of our statistics
+    monitor = PacketMonitor()
+    monitor.start_monitoring()
 
-    while True:
-        header, data = node.read()
-        if not data:
-            continue
+    with Live(monitor.generate_stat_table(), refresh_per_second=4) as live:
+        while not stop.is_set():
+            read_ret = node.read()
+            if read_ret is None:
+                print("Could not get a valid read from the node")
+                continue
 
-        packet_count += 1
+            synapse_data, bytes_read = read_ret
+            if synapse_data is None or bytes_read == 0:
+                print("Could not read data from node")
+                continue
+            header, data = synapse_data
+            monitor.process_packet(header, data, bytes_read)
+            live.update(monitor.generate_stat_table())
 
-        # Detect dropped packets via seq_number
-        if seq_number is None:
-            seq_number = header.seq_number
-        else:
-            expected = (seq_number + 1) % (2**16)
-            if header.seq_number != expected:
-                print(f"Seq out of order: got {header.seq_number}, expected {expected}")
-                dropped_packets += header.seq_number - expected
-            seq_number = header.seq_number
+            # Always add the data to the writer queues
+            q.put(data)
+            if plot_q:
+                plot_q.put(copy.deepcopy(data))
 
-        # Always add the data to the writer queues
-        q.put(data)
-        if plot_q:
-            plot_q.put(copy.deepcopy(data))
-
-        if packet_count == 1:
-            print(f"First packet received at {time.time() - start:.2f} seconds")
-
-        if packet_count % print_interval == 0:
-            print(
-                f"Recieved {packet_count} packets in {time.time() - start} seconds. Dropped {dropped_packets} packets ({(dropped_packets / packet_count) * 100}%)"
-            )
-        if duration and (time.time() - start) > duration:
-            break
-
-    print(
-        f"Recieved {packet_count} packets in {time.time() - start} seconds. Dropped {dropped_packets} packets ({(dropped_packets / packet_count) * 100}%)"
-    )
+            if duration and (time.time() - start) > duration:
+                break
 
 
 def _binary_writer(stop, q, num_ch, output_base):

--- a/synapse/cli/streaming.py
+++ b/synapse/cli/streaming.py
@@ -253,10 +253,7 @@ def read(args):
     console.print("[bold green]Streaming complete")
     console.print("[cyan]================")
     console.print(f"[cyan]Output directory: {output_base}/")
-    if args.bin:
-        console.print(f"[cyan]{output_base}.dat")
-    else:
-        console.print(f"[cyan]{output_base}.jsonl")
+    console.print(f"[cyan]Run `synapsectl plot --dir {output_base}/` to plot the data")
     console.print("[cyan]================")
 
 

--- a/synapse/client/node.py
+++ b/synapse/client/node.py
@@ -29,7 +29,6 @@ class Node(object):
         oneof = proto.WhichOneof("config")
         if oneof and hasattr(proto, oneof):
             config = getattr(proto, oneof)
-
         node = cls._from_proto(config)
         node.id = proto.id
         return node

--- a/synapse/client/nodes/stream_out.py
+++ b/synapse/client/nodes/stream_out.py
@@ -1,9 +1,7 @@
-import os
 import logging
 import socket
-import struct
 import traceback
-from typing import Optional
+from typing import Optional, Tuple
 
 from synapse.api.datatype_pb2 import DataType
 from synapse.api.node_pb2 import NodeConfig, NodeType
@@ -14,100 +12,109 @@ from synapse.utils.ndtp_types import (
     ElectricalBroadbandData,
     SpiketrainData,
     SynapseData,
+    NDTPHeader,
 )
+
+DEFAULT_STREAM_OUT_PORT = 50038
+
+
+# Try to get the current user's ip for setting the destination address
+def get_client_ip():
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        # This won't actually establish a connection, but helps us figure out the ip
+        s.connect(("8.8.8.8", 80))
+        local_ip = s.getsockname()[0]
+    except Exception as e:
+        logging.error(f"Failed to get client IP: {e}")
+        return None
+    finally:
+        s.close()
+    return local_ip
 
 
 class StreamOut(Node):
     type = NodeType.kStreamOut
 
-    def __init__(self, label=None, multicast_group=None):
+    def __init__(self, label=None, destination_address=None, destination_port=None):
         self.__socket = None
         self.__label = label
-        self.__multicast_group: Optional[str] = multicast_group
 
-    def read(self) -> Optional[SynapseData]:
+        # If we have been passed a None for destination address, try to resolve it
+        if not destination_address:
+            self.__destination_address = get_client_ip()
+        else:
+            self.__destination_address = destination_address
+
+        if not destination_port:
+            self.__destination_port = DEFAULT_STREAM_OUT_PORT
+        else:
+            self.__destination_port = destination_port
+
+    def read(self) -> Tuple[Optional[Tuple[NDTPHeader, SynapseData]], int]:
         if self.__socket is None:
             if self.open_socket() is None:
                 return None
         data, _ = self.__socket.recvfrom(8192)
-        return self._unpack(data)
+        bytes_read = len(data)
+        return self._unpack(data), bytes_read
 
     def open_socket(self):
-        print("Opening socket")
+        logging.info(
+            f"Opening socket at {self.__destination_address}:{self.__destination_port}"
+        )
         if self.device is None:
             logging.error("Node has no device")
             return None
 
-        node_socket = next(
-            (s for s in self.device.sockets if s.node_id == self.id), None
-        )
-        if node_socket is None:
-            logging.error("Couldnt find socket for node")
-            return None
-
-        bind = node_socket.bind.split(":")
-        if len(bind) != 2:
-            logging.error("Invalid bind address")
-            return None
-
-        addr = (
-            self.__multicast_group
-            if self.__multicast_group
-            else self.device.uri.split(":")[0]
-        )
-        if addr is None:
-            logging.error("Invalid bind address")
-            return None
-
-        port = int(bind[1])
-        if not port:
-            logging.error(f"Invalid bind port. Bind string: {bind}")
-            return None
-
-        logging.info(f"Opening UDP multicast socket to {addr}:{port}")
-
+        # UDP socket
         self.__socket = socket.socket(
             socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP
         )
+
+        # Allow reuse for easy restart
         self.__socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 
-        SOCKET_BUFSIZE_BYTES = 5 * 1024 * 1024 # 5MB
-        self.__socket.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, SOCKET_BUFSIZE_BYTES)
+        # Try to set a large recv buffer
+        SOCKET_BUFSIZE_BYTES = 5 * 1024 * 1024  # 5MB
+        self.__socket.setsockopt(
+            socket.SOL_SOCKET, socket.SO_RCVBUF, SOCKET_BUFSIZE_BYTES
+        )
         recvbuf = self.__socket.getsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF)
-
         if recvbuf < SOCKET_BUFSIZE_BYTES:
-            logging.warning(f"Could not set socket buffer size to {SOCKET_BUFSIZE_BYTES}. Current size is {recvbuf}. Consider increasing the system limit.")
-
-        if os.name != "nt":
-            logging.info(f"binding to {addr}:{port}")
-            self.__socket.bind((addr, port))
-        else:
-            logging.info(f"binding to {port}")
-            self.__socket.bind(('', port))
-
-        if self.__multicast_group:
-            logging.info(f"joining multicast group {self.__multicast_group}")
-            host = socket.gethostbyname(socket.gethostname())
-            mreq = socket.inet_aton(addr) + socket.inet_aton(host)
-
-            mreq = struct.pack("4sL", socket.inet_aton(addr), socket.INADDR_ANY)
-            self.__socket.setsockopt(
-                socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, mreq
+            logging.warning(
+                f"Could not set socket buffer size to {SOCKET_BUFSIZE_BYTES}. Current size is {recvbuf}. Consider increasing the system limit."
             )
 
+        # Bind to the destination address (our ip) and port
+        try:
+            self.__socket.bind((self.__destination_address, self.__destination_port))
+        except Exception as e:
+            logging.error(
+                f"Failed to bind to {self.__destination_address}:{self.__destination_port}: {e}"
+            )
+            return None
         return self.__socket
 
     def _to_proto(self):
         n = NodeConfig()
 
         o = StreamOutConfig()
-        o.label = self.__label
-        o.multicast_group = self.__multicast_group
+        if self.__label:
+            o.label = self.__label
+        else:
+            o.label = "Stream Out"
+
+        if self.__destination_address:
+            o.udp_unicast.destination_address = self.__destination_address
+
+        if self.__destination_port:
+            o.udp_unicast.destination_port = self.__destination_port
 
         n.stream_out.CopyFrom(o)
         return n
 
-    def _unpack(self, data: bytes) -> SynapseData:
+    def _unpack(self, data: bytes) -> Tuple[NDTPHeader, SynapseData]:
         u = None
         try:
             u = NDTPMessage.unpack(data)
@@ -133,4 +140,28 @@ class StreamOut(Node):
         if not isinstance(proto, StreamOutConfig):
             raise ValueError("proto is not of type StreamOutConfig")
 
-        return StreamOut(proto.label, proto.multicast_group)
+        # We currently only support udp unicast
+        selected_transport = proto.WhichOneof("transport")
+
+        if selected_transport is None:
+            # Set the defaults
+            destination_address = get_client_ip()
+            destination_port = DEFAULT_STREAM_OUT_PORT
+            logging.info(
+                f"Requesting StreamOut to: {destination_address}:{destination_port}"
+            )
+            return StreamOut(proto.label, destination_address, destination_port)
+        elif selected_transport == "udp_unicast":
+            dest_address = proto.udp_unicast.destination_address
+            dest_port = proto.udp_unicast.destination_port
+            if dest_address == "":
+                dest_address = get_client_ip()
+            if dest_port == 0:
+                dest_port = DEFAULT_STREAM_OUT_PORT
+            logging.info(
+                f"Using user provided StreamOut destination: {dest_address}:{dest_port}"
+            )
+            return StreamOut(proto.label, dest_address, dest_port)
+        else:
+            logging.error(f"Unsupported transport: {selected_transport}")
+            return None

--- a/synapse/examples/stream_out.py
+++ b/synapse/examples/stream_out.py
@@ -1,5 +1,8 @@
 import synapse as syn
 import sys
+import time
+
+SIMULATED_PERIPHERAL_ID = 100
 
 if __name__ == "__main__":
     uri = sys.argv[1] if len(sys.argv) > 1 else "127.0.0.1:647"
@@ -10,18 +13,21 @@ if __name__ == "__main__":
     print("Device info:")
     print(info)
 
-    stream_out = syn.StreamOut(label="my broadband", multicast_group="224.0.0.1")
-    
+    # The StreamOut node will automatically set your dest IP and port
+    stream_out = syn.StreamOut(label="my broadband")
+
     channels = [
         syn.Channel(
             id=channel_num,
             electrode_id=channel_num * 2,
-            reference_id=channel_num * 2 + 1
-        ) for channel_num in range(32)
+            reference_id=channel_num * 2 + 1,
+        )
+        for channel_num in range(32)
     ]
-    
+
     broadband = syn.BroadbandSource(
-        peripheral_id=2,
+        # Use the simulated peripheral (100), or replace with your own
+        peripheral_id=SIMULATED_PERIPHERAL_ID,
         sample_rate_hz=30000,
         bit_width=12,
         gain=20.0,
@@ -31,7 +37,7 @@ if __name__ == "__main__":
                 low_cutoff_hz=500.0,
                 high_cutoff_hz=6000.0,
             )
-        )
+        ),
     )
 
     config = syn.Config()
@@ -46,5 +52,37 @@ if __name__ == "__main__":
     assert info is not None, "Couldn't get device info"
     print("Configured device info:")
     print(info)
-    
+
+    should_run = True
+    total_bytes_read = 0
+    start_time = time.time()
+    last_update_time = start_time
+    update_interval_sec = 1
+    while should_run:
+        try:
+            # Wait for data
+            syn_data, bytes_read = stream_out.read()
+            if syn_data is None or bytes_read == 0:
+                print("Failed to read data from node")
+                continue
+            # Do something with the data
+            _header, _data = syn_data
+            total_bytes_read += bytes_read
+
+            current_time = time.time()
+            if (current_time - last_update_time) >= update_interval_sec:
+                sys.stdout.write("\r")
+                sys.stdout.write(
+                    f"{total_bytes_read} bytes in {time.time() - start_time:.2f} sec"
+                )
+                last_update_time = current_time
+
+            if current_time - start_time > 5:
+                should_run = False
+
+        except KeyboardInterrupt:
+            print("Keyboard interrupt detected, stopping")
+            should_run = False
+
+    print("Stopping device")
     device.stop()

--- a/synapse/server/entrypoint.py
+++ b/synapse/server/entrypoint.py
@@ -101,6 +101,7 @@ async def async_main(args, node_object_map, peripherals):
             args.name,
             args.serial,
             args.rpc_port,
+            args.iface_ip,
             node_object_map,
             peripherals,
         )

--- a/synapse/server/entrypoint.py
+++ b/synapse/server/entrypoint.py
@@ -12,6 +12,7 @@ from synapse.server.rpc import serve
 from synapse.server.autodiscovery import BroadcastDiscoveryProtocol
 from synapse.server.nodes import SERVER_NODE_OBJECT_MAP
 
+logging.basicConfig(level=logging.INFO)
 
 ENTRY_DEFAULTS = {
     "iface_ip": None,
@@ -33,7 +34,7 @@ def main(
     )
     parser.add_argument(
         "--iface-ip",
-        help="IP of the network interface to use for multicast traffic",
+        help="IP of the network interface to use for streaming data",
         required=True,
     )
     parser.add_argument(
@@ -50,7 +51,7 @@ def main(
     )
     parser.add_argument(
         "--discovery-addr",
-        help="Multicast address to listen for discovery requests",
+        help="UDP address to listen for discovery requests",
         default=defaults["discovery_addr"],
     )
     parser.add_argument("--name", help="Device name", default=defaults["server_name"])
@@ -70,7 +71,7 @@ def main(
         s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         s.bind((args.iface_ip, 8000))
         logging.info(f"Binding to {s.getsockname()[0]}...")
-    except Exception as e:
+    except Exception:
         parser.error("Invalid --iface-ip given, could not bind to interface")
     finally:
         s.close()
@@ -100,7 +101,6 @@ async def async_main(args, node_object_map, peripherals):
             args.name,
             args.serial,
             args.rpc_port,
-            args.iface_ip,
             node_object_map,
             peripherals,
         )

--- a/synapse/server/rpc.py
+++ b/synapse/server/rpc.py
@@ -15,17 +15,30 @@ from synapse.api.synapse_pb2_grpc import (
     SynapseDeviceServicer,
     add_SynapseDeviceServicer_to_server,
 )
-from synapse.utils.logging import StreamingLogHandler, init_file_handler, str_to_log_entry
+from synapse.utils.logging import (
+    StreamingLogHandler,
+    init_file_handler,
+    str_to_log_entry,
+)
 
 
 LOG_FILEPATH = str(Path.home() / ".science" / "synapse" / "logs" / "server.log")
 
+
 async def serve(
-    server_name, device_serial, rpc_port, iface_ip, node_object_map, peripherals, services: List[Callable[[str, grpc.aio.Server], None]] = []
+    server_name,
+    device_serial,
+    rpc_port,
+    iface_ip,
+    node_object_map,
+    peripherals,
+    services: List[Callable[[str, grpc.aio.Server], None]] = [],
 ) -> None:
     server = grpc.aio.server()
     add_SynapseDeviceServicer_to_server(
-        SynapseServicer(server_name, device_serial, node_object_map, peripherals),
+        SynapseServicer(
+            server_name, device_serial, iface_ip, node_object_map, peripherals
+        ),
         server,
     )
 
@@ -36,6 +49,7 @@ async def serve(
     await server.start()
     await server.wait_for_termination()
 
+
 class SynapseServicer(SynapseDeviceServicer):
     """Provides methods that implement functionality of a Synapse device server."""
 
@@ -44,7 +58,7 @@ class SynapseServicer(SynapseDeviceServicer):
     connections = []
     nodes = []
 
-    def __init__(self, name, serial, node_object_map, peripherals):
+    def __init__(self, name, serial, iface_ip, node_object_map, peripherals):
         self.name = name
         self.serial = serial
         self.node_object_map = node_object_map
@@ -157,7 +171,9 @@ class SynapseServicer(SynapseDeviceServicer):
     async def GetLogs(self, request, context):
         self.logger.info("GetLogs()")
         try:
-            min_level = request.min_level if request.min_level else LogLevel.LOG_LEVEL_INFO
+            min_level = (
+                request.min_level if request.min_level else LogLevel.LOG_LEVEL_INFO
+            )
             entries = []
 
             if request.since_ms:
@@ -166,15 +182,16 @@ class SynapseServicer(SynapseDeviceServicer):
                 end_time_ns = current_time_ns
             else:
                 start_time_ns = request.start_time_ns if request.start_time_ns else 0
-                end_time_ns = request.end_time_ns if request.end_time_ns else time.time_ns()
-
+                end_time_ns = (
+                    request.end_time_ns if request.end_time_ns else time.time_ns()
+                )
 
             if not Path(LOG_FILEPATH).exists():
                 self.logger.warning(f"Log file not found at {LOG_FILEPATH}")
-                await context.abort(grpc.StatusCode.NOT_FOUND, f"no log file found")
+                await context.abort(grpc.StatusCode.NOT_FOUND, "no log file found")
 
             try:
-                with open(LOG_FILEPATH, 'r') as f:
+                with open(LOG_FILEPATH, "r") as f:
                     for line in f:
                         try:
                             entry = str_to_log_entry(line)
@@ -187,13 +204,15 @@ class SynapseServicer(SynapseDeviceServicer):
                             if entry.level < min_level:
                                 continue
                             entries.append(entry)
-                        except Exception as e:
-                            self.logger.warning(f"failed to parse log line: {line} - skipping")
+                        except Exception:
+                            self.logger.warning(
+                                f"failed to parse log line: {line} - skipping"
+                            )
                             continue
 
             except FileNotFoundError:
                 self.logger.warning(f"Log file not found at {LOG_FILEPATH}")
-                await context.abort(grpc.StatusCode.UNKNOWN, f"failed to open log file")
+                await context.abort(grpc.StatusCode.UNKNOWN, "failed to open log file")
 
             return LogQueryResponse(entries=entries)
 
@@ -204,8 +223,10 @@ class SynapseServicer(SynapseDeviceServicer):
     async def TailLogs(self, request, context):
         self.logger.info("TailLogs()")
         try:
-            min_level = request.min_level if request.min_level else LogLevel.LOG_LEVEL_INFO
-            
+            min_level = (
+                request.min_level if request.min_level else LogLevel.LOG_LEVEL_INFO
+            )
+
             log_queue = asyncio.Queue(maxsize=100)
 
             def handle_log(record: str):
@@ -213,14 +234,14 @@ class SynapseServicer(SynapseDeviceServicer):
                     log_queue.put_nowait(record)
                 except asyncio.QueueFull:
                     self.logger.warning("Log queue full - dropping log")
-            
+
             self.active_streams.add(handle_log)
 
             try:
                 while True:
                     try:
                         formatted_record = await log_queue.get()
-                        
+
                         try:
                             entry = str_to_log_entry(formatted_record)
                             if not entry:
@@ -231,7 +252,9 @@ class SynapseServicer(SynapseDeviceServicer):
                             yield entry
 
                         except Exception as e:
-                            self.logger.warning(f"Failed to parse log record: {formatted_record} - {str(e)}")
+                            self.logger.warning(
+                                f"Failed to parse log record: {formatted_record} - {str(e)}"
+                            )
                             continue
 
                     except asyncio.CancelledError:
@@ -242,11 +265,13 @@ class SynapseServicer(SynapseDeviceServicer):
 
         except Exception as e:
             self.logger.error(f"Error tailing logs: {str(e)}")
-            await context.abort(grpc.StatusCode.UNKNOWN, f"failed to tail logs: {str(e)}")
+            await context.abort(
+                grpc.StatusCode.UNKNOWN, f"failed to tail logs: {str(e)}"
+            )
             return
 
     def __del__(self):
-        if hasattr(self, 'stream_handler'):
+        if hasattr(self, "stream_handler"):
             logging.getLogger().removeHandler(self.stream_handler)
 
     def _broadcast_log(self, formatted_record: str) -> None:

--- a/synapse/server/rpc.py
+++ b/synapse/server/rpc.py
@@ -25,9 +25,7 @@ async def serve(
 ) -> None:
     server = grpc.aio.server()
     add_SynapseDeviceServicer_to_server(
-        SynapseServicer(
-            server_name, device_serial, iface_ip, node_object_map, peripherals
-        ),
+        SynapseServicer(server_name, device_serial, node_object_map, peripherals),
         server,
     )
 
@@ -46,10 +44,9 @@ class SynapseServicer(SynapseDeviceServicer):
     connections = []
     nodes = []
 
-    def __init__(self, name, serial, iface_ip, node_object_map, peripherals):
+    def __init__(self, name, serial, node_object_map, peripherals):
         self.name = name
         self.serial = serial
-        self.iface_ip = iface_ip
         self.node_object_map = node_object_map
         self.peripherals = peripherals
         self.logger = logging.getLogger("server")
@@ -288,7 +285,7 @@ class SynapseServicer(SynapseDeviceServicer):
                 "Creating %s node(%d)" % (NodeType.Name(node.type), node.id)
             )
             node = self.node_object_map[node.type](node.id)
-            if node.type in [NodeType.kStreamOut, NodeType.kStreamIn]:
+            if node.type in [NodeType.kStreamIn]:
                 node.configure_iface_ip(self.iface_ip)
 
             status = node.configure(config)

--- a/synapse/tests/util/test_packet_monitor.py
+++ b/synapse/tests/util/test_packet_monitor.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+import unittest
+
+from synapse.utils.packet_monitor import PacketMonitor
+
+
+class PacketMonitorTest(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_handle_sequence_number(self):
+        packet_monitor = PacketMonitor()
+
+        # Start with zero
+        packet_monitor.handle_sequence_number(0)
+        self.assertEqual(packet_monitor.current_seq_number, 0)
+
+        packet_monitor.handle_sequence_number(1)
+        self.assertEqual(packet_monitor.current_seq_number, 1)
+
+        # Dropped a packet
+        packet_monitor.handle_sequence_number(3)
+        self.assertEqual(packet_monitor.current_seq_number, 3)
+        self.assertEqual(packet_monitor.dropped_packets, 1)
+
+        # Dropped a bunch of packets (we expect to be at 4, but we are at 1000)
+        # Dropped packets is 1000 - 4 + the previous dropped
+        packet_monitor.handle_sequence_number(1000)
+        self.assertEqual(packet_monitor.current_seq_number, 1000)
+        self.assertEqual(packet_monitor.dropped_packets, 1 + (1000 - 4))
+
+    def test_handle_wrap_around(self):
+        packet_monitor = PacketMonitor()
+
+        # Start near the threshold
+        start_index = (2**16) - 1
+        packet_monitor.handle_sequence_number(start_index)
+        self.assertEqual(packet_monitor.dropped_packets, 0)
+        self.assertEqual(packet_monitor.current_seq_number, start_index)
+
+        # Drop some packets
+        packet_monitor.handle_sequence_number(10)
+        self.assertEqual(packet_monitor.dropped_packets, (2**16 - start_index) + 10)
+        self.assertEqual(packet_monitor.current_seq_number, 10)
+        dropped_so_far = packet_monitor.dropped_packets
+
+        # Continue
+        packet_monitor.handle_sequence_number(100)
+        self.assertEqual(packet_monitor.dropped_packets, dropped_so_far + (100 - 11))
+        self.assertEqual(packet_monitor.current_seq_number, 100)
+
+    def test_handle_ooo(self):
+        packet_monitor = PacketMonitor()
+        packet_monitor.handle_sequence_number(10)
+        self.assertEqual(packet_monitor.dropped_packets, 0)
+        self.assertEqual(packet_monitor.current_seq_number, 10)
+        self.assertEqual(packet_monitor.out_of_order_packets, 0)
+
+        packet_monitor.handle_sequence_number(9)
+        self.assertEqual(packet_monitor.dropped_packets, 0)
+        self.assertEqual(packet_monitor.current_seq_number, 9)
+        self.assertEqual(packet_monitor.out_of_order_packets, 1)
+
+        packet_monitor.handle_sequence_number(11)
+        self.assertEqual(packet_monitor.dropped_packets, 1)
+        self.assertEqual(packet_monitor.current_seq_number, 11)
+        self.assertEqual(packet_monitor.out_of_order_packets, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/synapse/utils/packet_monitor.py
+++ b/synapse/utils/packet_monitor.py
@@ -1,0 +1,132 @@
+import time
+from rich.table import Table
+
+
+class PacketMonitor:
+    def __init__(self):
+        # Packet tracking
+        self.packet_count = 0
+        self.current_seq_number = None
+        self.dropped_packets = 0
+        self.out_of_order_packets = 0
+
+        # Timing metrics
+        self.start_time = None
+        self.first_packet_time = None
+
+        # Bandwidth tracking
+        self.bytes_received = 0
+        self.bytes_received_in_interval = 0
+        self.bandwidth_samples = []
+        self.last_bandwidth_time = None
+        self.last_bytes_received = 0
+        self.last_bandwidth = 0
+
+        # Jitter tracking
+        self.last_packet_time = None
+        self.last_jitter = 0
+        self.avg_jitter = 0
+
+    def start_monitoring(self):
+        """Initialize monitoring timers"""
+        self.start_time = time.time()
+        self.last_stats_time = self.start_time
+        self.last_bandwidth_time = self.start_time
+
+    def process_packet(self, header, data, bytes_read):
+        if not data:
+            return False
+        packet_received_time = time.time()
+        # Record first packet time
+        if self.packet_count == 0:
+            self.first_packet_time = packet_received_time
+            self.last_packet_time = packet_received_time
+        else:
+            # Calculate jitter
+            interval = packet_received_time - self.last_packet_time
+            # Update jitter using RFC 3550 algorithm (smoother than just max-min)
+            # https://datatracker.ietf.org/doc/html/rfc3550#appendix-A.8
+            if self.packet_count > 1:
+                jitter_diff = abs(interval - self.last_jitter)
+                self.avg_jitter += (jitter_diff - self.avg_jitter) / 16
+
+            # Save current values for next calculation
+            self.last_jitter = interval
+            self.last_packet_time = packet_received_time
+
+        # We got a new packet
+        self.packet_count += 1
+        self.bytes_received += bytes_read
+        self.bytes_received_in_interval += bytes_read
+
+        self.handle_sequence_number(header.seq_number)
+
+        return True
+
+    def sequence_distance(self, first, second):
+        max_seq_num = 2**16 + 1
+        # Force the inputs to a valid range
+        first %= max_seq_num
+        second %= max_seq_num
+
+        # Get the distance in both directions (because it is a circle)
+        forward = (first - second) % max_seq_num
+        backward = (second - first) % max_seq_num
+
+        # Get the shortest distance with the correct sign
+        if forward <= backward:
+            return forward
+        else:
+            return -1 * backward
+
+    def handle_sequence_number(self, recv_seq_number):
+        # Make sure the sequence number we get is in the range
+        sequence_number = recv_seq_number % (2**16 + 1)
+
+        if self.current_seq_number is None:
+            self.current_seq_number = sequence_number
+            return
+
+        # we expect to see it monotonically increase
+        expected_seq = (self.current_seq_number + 1) % (2**16 + 1)
+        distance = self.sequence_distance(sequence_number, expected_seq)
+
+        # Handle the case where it isn't what we expect
+        if distance > 0:
+            # Forward distance means packets were dropped
+            self.dropped_packets += distance
+        elif distance < 0:
+            # negative distance means out of order packets
+            self.out_of_order_packets += 1
+        else:
+            # We got a fine packet
+            pass
+
+        # Always update with the latest seq number
+        self.current_seq_number = sequence_number
+
+    def generate_stat_table(self) -> Table:
+        table = Table()
+        table.add_column("Runtime (sec)")
+        table.add_column("Dropped (%)")
+        table.add_column("Mbit/sec")
+        table.add_column("Jitter (ms)")
+        table.add_column("Out of Order")
+
+        now = time.time()
+        runtime_sec = now - self.start_time
+        drop_percent = (self.dropped_packets / max(1, self.packet_count)) * 100.0
+        dt_sec = now - self.last_bandwidth_time
+        if dt_sec > 0:
+            bytes_per_second = self.bytes_received_in_interval / dt_sec
+            megabits_per_second = (bytes_per_second * 8) / 1_000_000
+            self.last_bandwidth = megabits_per_second
+        jitter_ms = self.avg_jitter * 1000
+        table.add_row(
+            f"{runtime_sec:.1f}",
+            f"{self.dropped_packets}/{self.packet_count} ({drop_percent:.1f}%)",
+            f"{self.last_bandwidth:.2f}",
+            f"{jitter_ms:.1f}",
+            f"{self.out_of_order_packets}",
+        )
+        return table

--- a/test_config.json
+++ b/test_config.json
@@ -4,7 +4,6 @@
       "type": "kStreamOut",
       "id": 1,
       "stream_out": {
-        "multicast_group": "224.0.0.115"
       }
     },
     {


### PR DESCRIPTION
# Summary
In preparation for switching to UDP unicast, we have updated the StreamOut configuration to support udp unicast

# Changes
* Updates synapse api
* Modularizes packet loss/bitrate calculation in streaming
* Updates stream out to use Udp unicast


# Migration
StreamOut configurations can just be defined like this (with an empty configuration for stream_out)
```
    {
      "type": "kStreamOut",
      "id": 1,
      "stream_out": {
      }
    },
```
The client will automatically fill with the clients IP and a default streaming port. You can also set a different port yourself, like this:

```
    {
      "type": "kStreamOut",
      "id": 1,
      "stream_out": {
        "udp_unicast": {
          "destination_port": 12345
        }
      }
    },
```

Specific IP addresses will not work, unless it is your own. In most cases, just let the client figure out the correct IP/Port to use.

# Testing
  * Tested streaming from a device with the updated server
  * Tested running the example on a device with an updated server
  * Tested with starting/reading from synapse-sim
    * e.g. synapse-sim --rpc-port 50098
