### PR TITLE
Remove duplicated configuration in streaming.py

### DIFF
--- a/synapse/cli/streaming.py
+++ b/synapse/cli/streaming.py
@@ -158,9 +158,6 @@ def read(args):
                 return
             console.print("[bold green]Device configured successfully")
 
-        if not device.configure(config):
-            raise ValueError("Failed to configure device")
-
         if info.status.state != DeviceState.kRunning:
             print("Starting device...")
             if not device.start():


### PR DESCRIPTION
We were accidentally calling configure() a second time after configure() was called the first time. 