### PR TITLE
fix: fix missing import needed for impedance results saving

### DIFF
--- a/synapse/cli/rpc.py
+++ b/synapse/cli/rpc.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import time
 from datetime import datetime
 from typing import Optional
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/Users/antoniae/projects/science/synapse/.venv/bin/synapsectl", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/antoniae/projects/science/synapse/synapse-python/synapse/cli/__main__.py", line 43, in main
    args.func(args)
  File "/Users/antoniae/projects/science/synapse/synapse-python/synapse/cli/rpc.py", line 113, in query
    f"impedance_measurements_{time.strftime('%Y%m%d-%H%M%S')}.csv", "w"
                              ^^^^
```