### PR TITLE
feat: add `get_last_sync_time_ns` to TimeSyncClient

### DIFF
--- a/synapse/utils/time_sync.py
+++ b/synapse/utils/time_sync.py
@@ -148,14 +148,14 @@ class TimeSyncClient:
             response.client_receive_time_ns = now_ns
 
             if response.client_id != self.client_id:
-                self.logger.warn(f"Received sync packet from {response.client_id}, but expected {self.client_id}")
+                self.logger.warning(f"Received sync packet from {response.client_id}, but expected {self.client_id}")
                 return
 
             estimate = get_time_sync_estimate(response)
             self.logger.debug(f"updating estimate for sync packet {self.sequence_number} / {self.config.max_sync_packets}")
 
             if self.sequence_number >= self.config.max_sync_packets:
-                self.logger.warn(f"Received sync packet {self.sequence_number} / {self.config.max_sync_packets}, but max is {self.config.max_sync_packets}")
+                self.logger.warning(f"Received sync packet {self.sequence_number} / {self.config.max_sync_packets}, but max is {self.config.max_sync_packets}")
                 return
 
             self.current_rtts[self.sequence_number] = estimate

--- a/synapse/utils/time_sync.py
+++ b/synapse/utils/time_sync.py
@@ -110,9 +110,8 @@ class TimeSyncClient:
             self.logger.debug(f"Synced with {self.config.max_sync_packets} packets, updating estimate - current offset: {self.latest_offset_ns} ns")
             time.sleep(self.config.sync_interval_s)
             if self.running:
-                self.sequence_number = 0
                 self._send_next_sync_packet()
-
+    
         else:
             time.sleep(self.config.send_delay_ms / 1000.0)
             if self.running:
@@ -165,6 +164,8 @@ class TimeSyncClient:
 
         self.current_rtts[self.sequence_number] = estimate
 
+        self.last_sync_time_ns = [time.time_ns(), self.time_ns()]
+
         self._schedule_next_sync()
 
     def _update_estimate(self):
@@ -175,7 +176,6 @@ class TimeSyncClient:
                           key=lambda x: x.rtt_ns)
         
         self.latest_offset_ns = best_estimate.offset_ns
-        self.last_sync_time_ns = [time.time_ns(), self.time_ns()]
         self.sequence_number = 0
         self.current_rtts = [TimeSyncEstimate() for _ in range(self.config.max_sync_packets)]
 

--- a/synapse/utils/time_sync.py
+++ b/synapse/utils/time_sync.py
@@ -112,7 +112,7 @@ class TimeSyncClient:
         self.worker_thread.daemon = True
         self.worker_thread.start()
 
-        self.logger.info(f"TimeSyncClient started")
+        self.logger.info("TimeSyncClient started")
         return True
 
     def stop(self):
@@ -163,7 +163,7 @@ class TimeSyncClient:
             return
 
         if self.sequence_number == 0:
-            self.logger.debug(f"Sending sync packets...")
+            self.logger.debug("Sending sync packets...")
 
         request = TimeSyncPacket()
         request.client_id = self.client_id


### PR DESCRIPTION
* feat: add `get_last_sync_time_ns` to TimeSyncClient
* fix: fix issue where TimeSyncClient would send too many packets (send next packet upon previous receipt of previous packet's response, or timeout waiting for response)


To test
```
# install package, preferably in a venv
source .venv/bin/activate
pip install -e .

# then run the time sync client
python synapse/utils/time_sync.py --host <your time server IP / scifi server IP>
```

`starling` and `fluffy-eldritch-hummingbird` support the time server and you may use their IPs.