### PR TITLE
feat: Fix issue where uri is forgotten

### DIFF
--- a/synapse/cli/__main__.py
+++ b/synapse/cli/__main__.py
@@ -71,9 +71,14 @@ def main():
     if not args:
         return
 
-    if hasattr(args, "func"):
-        args.func(args)
-    else:
+    try:
+        if hasattr(args, "func"):
+            args.func(args)
+        else:
+            parser.print_help()
+    except Exception as e:
+        console = Console()
+        console.log(f"[bold red] Uncaught error during function. Why: {e}")
         parser.print_help()
 
 

--- a/synapse/cli/__main__.py
+++ b/synapse/cli/__main__.py
@@ -80,6 +80,8 @@ def main():
         console = Console()
         console.log(f"[bold red] Uncaught error during function. Why: {e}")
         parser.print_help()
+    except KeyboardInterrupt:
+        print("User cancelled request")
 
 
 if __name__ == "__main__":

--- a/synapse/client/device.py
+++ b/synapse/client/device.py
@@ -23,6 +23,8 @@ class Device(object):
     sockets = None
 
     def __init__(self, uri, verbose=False):
+        if not uri:
+            raise ValueError("URI cannot be empty or none")
         if len(uri.split(":")) != 2:
             self.uri = uri + f":{DEFAULT_SYNAPSE_PORT}"
         else:


### PR DESCRIPTION
# Summary
If we pass in a None uri, then we get an error. This catches it and explains the issue, while also printing the help.

# Testing
 - tested without -u flag
