### PR TITLE
fix: fix issue with LogLevel type annotation on certain client device methods

### DIFF
--- a/synapse/client/device.py
+++ b/synapse/client/device.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from typing import AsyncGenerator, Optional, Union
 import grpc
 from google.protobuf.empty_pb2 import Empty


### PR DESCRIPTION
Fixes error on some client Device methods on python v ~= 3.10
``` 
~/p/s/sy/synapse-python feature/doub…plot-parsing ❯ synapsectl plot --dir 2025-04-25-broadband-filter-hg-anterior
Traceback (most recent call last):
  File "/Users/antoniae/projects/science/synapse/synapse-python/.venv_debug/bin/synapsectl", line 5, in <module>
    from synapse.cli import main
  File "/Users/antoniae/projects/science/synapse/synapse-python/synapse/__init__.py", line 1, in <module>
    from synapse.client import *
  File "/Users/antoniae/projects/science/synapse/synapse-python/synapse/client/__init__.py", line 3, in <module>
    from synapse.client.device import Device
  File "/Users/antoniae/projects/science/synapse/synapse-python/synapse/client/device.py", line 22, in <module>
    class Device(object):
  File "/Users/antoniae/projects/science/synapse/synapse-python/synapse/client/device.py", line 117, in Device
    log_level: Union[str, LogLevel] = "INFO",
  File "/Users/antoniae/.pyenv/versions/3.10.12/lib/python3.10/typing.py", line 312, in inner
    return func(*args, **kwds)
  File "/Users/antoniae/.pyenv/versions/3.10.12/lib/python3.10/typing.py", line 403, in __getitem__
    return self._getitem(self, parameters)
  File "/Users/antoniae/.pyenv/versions/3.10.12/lib/python3.10/typing.py", line 515, in Union
    parameters = tuple(_type_check(p, msg) for p in parameters)
  File "/Users/antoniae/.pyenv/versions/3.10.12/lib/python3.10/typing.py", line 515, in <genexpr>
    parameters = tuple(_type_check(p, msg) for p in parameters)
  File "/Users/antoniae/.pyenv/versions/3.10.12/lib/python3.10/typing.py", line 176, in _type_check
    raise TypeError(f"{msg} Got {arg!r:.100}.")
TypeError: Union[arg, ...]: each arg must be a type. Got <google.protobuf.internal.enum_type_wrapper.EnumTypeWrapper object at 0x100aab8b0>.
```