### PR TITLE
Feature: Allow for user defined protobufs

### DIFF
--- a/synapse/cli/device_info_display.py
+++ b/synapse/cli/device_info_display.py
@@ -1,37 +1,28 @@
-import time
 from rich.console import Console
-from rich.panel import Panel
-from rich.table import Table
 from rich.tree import Tree
 from google.protobuf.json_format import MessageToDict
 from synapse.client.device import Device
 
 
-def visualize_configuration(info_dict):
+def visualize_configuration(info_dict, status):
+    nodes_status = status.get("signal_chain", {}).get("nodes", {})
     config = info_dict.get("configuration", {})
     if config:
         tree = Tree("Configuration")
-        for node in config.get("nodes", []):
+        for index, node in enumerate(config.get("nodes", [])):
             node_type = node.get("type", "").replace("k", "")
-            node_name = node.get("name", "Unknown")
-            node_tree = tree.add(f"{node_name}")
+            node_tree = tree.add(f"{node_type}")
             node_tree.add(f"ID: {node.get('id', 'Unknown')}")
-            node_tree.add(f"Type: {node_type}")
-
             if node_type == "Application":
                 app = node.get("application", {})
                 name = app.get("name", "Unknown")
-                running = app.get("running", False)
-                status = "[green]Running[/green]" if running else "[red]Stopped[/red]"
+                status = nodes_status[index].get("application", None)
+                if status:
+                    status = status.get("running", False)
                 node_tree.add(f"Name: {name}")
-                node_tree.add(f"Status: {status}")
+                node_tree.add(f"Running: {status}")
             elif node_type == "BroadbandSource":
                 source = node.get("broadband_source", {})
-                name = source.get("name", "Unknown")
-                running = source.get("running", False)
-                status = "[green]Running[/green]" if running else "[red]Stopped[/red]"
-                node_tree.add(f"Name: {name}")
-                node_tree.add(f"Status: {status}")
                 if "signal" in source and "electrode" in source["signal"]:
                     channels = source["signal"]["electrode"].get("channels", [])
                     electrode_ids = [
@@ -113,4 +104,4 @@ class DeviceInfoDisplay:
                 )
 
             self.console.print(visualize_peripherals(info_dict))
-            self.console.print(visualize_configuration(info_dict))
+            self.console.print(visualize_configuration(info_dict, status))

--- a/synapse/cli/rpc.py
+++ b/synapse/cli/rpc.py
@@ -12,11 +12,11 @@ from google.protobuf import text_format
 from google.protobuf.json_format import Parse
 
 from rich.console import Console
-from rich.pretty import pprint
 
 from synapse.cli.query import StreamingQueryClient
 from synapse.utils.log import log_entry_to_str
 from synapse.cli.device_info_display import DeviceInfoDisplay
+from synapse.utils.proto import load_config
 
 
 def add_commands(subparsers):
@@ -196,10 +196,7 @@ def start(args):
 
         # Load the configuration proto and build Config object
         try:
-            with open(cfg_path, "r") as f:
-                json_text = f.read()
-            cfg_proto = Parse(json_text, DeviceConfiguration())
-            config_obj = syn.Config.from_proto(cfg_proto)
+            config_obj = load_config(cfg_path, console)
         except Exception as e:
             console.print(
                 f"[bold red]Failed to parse configuration file[/bold red]: {e}"

--- a/synapse/cli/rpc.py
+++ b/synapse/cli/rpc.py
@@ -196,6 +196,7 @@ def start(args):
         # Load the configuration proto and build Config object
         try:
             config_obj = load_config(cfg_path, console)
+            print(config_obj.nodes[0].name)
         except Exception as e:
             console.print(
                 f"[bold red]Failed to parse configuration file[/bold red]: {e}"

--- a/synapse/cli/rpc.py
+++ b/synapse/cli/rpc.py
@@ -196,7 +196,6 @@ def start(args):
         # Load the configuration proto and build Config object
         try:
             config_obj = load_config(cfg_path, console)
-            print(config_obj.nodes[0].name)
         except Exception as e:
             console.print(
                 f"[bold red]Failed to parse configuration file[/bold red]: {e}"

--- a/synapse/client/nodes/application_node.py
+++ b/synapse/client/nodes/application_node.py
@@ -6,12 +6,13 @@ from synapse.client.node import Node
 class ApplicationNode(Node):
     type = NodeType.kApplication
 
-    def __init__(self, name: str):
+    def __init__(self, name: str, parameters):
         self.name = name
+        self.parameters = parameters
 
     def _to_proto(self):
         n = NodeConfig()
-        p = ApplicationNodeConfig(name=self.name)
+        p = ApplicationNodeConfig(name=self.name, parameters=self.parameters)
         n.application.CopyFrom(p)
         return n
 
@@ -22,4 +23,4 @@ class ApplicationNode(Node):
         if not isinstance(proto, ApplicationNodeConfig):
             raise ValueError("proto is not of type ApplicationNodeConfig")
 
-        return ApplicationNode(name=proto.name)
+        return ApplicationNode(name=proto.name, parameters=proto.parameters)

--- a/synapse/utils/proto.py
+++ b/synapse/utils/proto.py
@@ -1,0 +1,84 @@
+import os
+from pathlib import Path
+from google.protobuf import descriptor_pb2, descriptor_pool
+from google.protobuf.json_format import Parse
+from synapse.api.synapse_pb2 import DeviceConfiguration
+from synapse.api.app_pb2 import AppManifest
+import synapse as syn
+
+
+def load_client_protos(descriptor_file_paths, console):
+    if not descriptor_file_paths:
+        return
+
+    pool = descriptor_pool.Default()
+    for desc_path in descriptor_file_paths:
+        if not os.path.exists(desc_path):
+            console.print(f"[red]Warning:[/red] Descriptor file not found: {desc_path}")
+            continue
+        try:
+            with open(desc_path, "rb") as f:
+                descriptor_data = f.read()
+
+            file_descriptor_set = descriptor_pb2.FileDescriptorSet()
+            file_descriptor_set.ParseFromString(descriptor_data)
+
+            for file_desc in file_descriptor_set.file:
+                try:
+                    pool.Add(file_desc)
+                    console.print(
+                        f"[green]Successfully loaded descriptor:[/green] {file_desc.name}"
+                    )
+                except Exception as e:
+                    console.print(
+                        f"[red]Warning:[/red] Could not add {file_desc.name} to pool: {e}"
+                    )
+
+        except Exception as e:
+            console.print(f"[red]Error:[/red] Loading descriptor {desc_path}: {e}")
+
+
+def load_config(path_to_config, console):
+    # We support either a manifest or a device configuration.
+    # First, try to load a device configuration
+    try:
+        json_text = open(path_to_config, "r").read()
+        cfg_proto = Parse(json_text, DeviceConfiguration())
+        return syn.Config.from_proto(cfg_proto)
+    except Exception:
+        pass
+
+    # We couldn't load a device configuration, so try to load a manifest
+    try:
+        json_text = open(path_to_config, "r").read()
+        manifest_proto = Parse(json_text, AppManifest())
+
+        # First, load the descriptors from the proto_files (but look for .desc)
+        manifest_dir = Path(path_to_config).resolve().parent
+
+        desc_files = []
+        for proto_file in manifest_proto.proto_files:
+            # Convert .proto path to .desc path
+            desc_file = Path(proto_file).with_suffix(".desc")
+            desc_path = manifest_dir / desc_file
+            desc_files.append(str(desc_path))
+
+        if desc_files:
+            load_client_protos(desc_files, console)
+
+        # Now load the device configuration from the specified path
+        device_config_path = manifest_dir / manifest_proto.device_config_path
+
+        if device_config_path.exists():
+            device_config_text = device_config_path.read_text()
+            cfg_proto = Parse(device_config_text, DeviceConfiguration())
+            return syn.Config.from_proto(cfg_proto)
+        else:
+            raise FileNotFoundError(f"Device config not found: {device_config_path}")
+
+    except Exception:
+        raise ValueError(
+            f"Could not parse {path_to_config} as either device configuration or manifest"
+        )
+
+    return None


### PR DESCRIPTION
# Summary
Updates the API to include support for user defined configuration parameters. Also fixes the device info display.

We need to do this because to send the server the device configuration with an Any type that is user defined, we need to point the python client to the correct location of the python descriptors. 

# Testing
```
# Load a manifest.json
python3 synapse/cli/__main__.py -u "device" start ../synapse-example-app/manifest.json

# Old device configuration also works
python3 synapse/cli/__main__.py -u "device" start ../synapse-example-app/config/device.json
```
