### PR TITLE
Feature: Tap API in simulated broadband source

### DIFF
--- a/synapse/examples/tap_example.py
+++ b/synapse/examples/tap_example.py
@@ -43,6 +43,13 @@ if __name__ == "__main__":
     config.add_node(broadband)
 
     device.configure(config)
+
+    # export the config to a json file for using with CLI
+    # from google.protobuf.json_format import MessageToJson
+    # with open("device_config.json", "w") as f:
+    #     f.write(MessageToJson(config.to_proto()))
+    # print("Config written to device_config.json")
+
     device.start()
 
     info = device.info()

--- a/synapse/examples/tap_example.py
+++ b/synapse/examples/tap_example.py
@@ -10,7 +10,9 @@ if __name__ == "__main__":
     uri = sys.argv[1] if len(sys.argv) > 1 else "127.0.0.1:647"
     device = syn.Device(uri)
     info = device.info()
-    assert info is not None, "Couldn't get device info"
+    if info is None:
+        print("Couldn't get device info")
+        sys.exit(1)
 
     print("Device info:")
     print(info)
@@ -53,7 +55,9 @@ if __name__ == "__main__":
     device.start()
 
     info = device.info()
-    assert info is not None, "Couldn't get device info"
+    if info is None:
+        print("Couldn't get device info")
+        sys.exit(1)
     print("Configured device info:")
     print(info)
 

--- a/synapse/examples/tap_example.py
+++ b/synapse/examples/tap_example.py
@@ -1,0 +1,90 @@
+import synapse as syn
+import sys
+import time
+
+from synapse.client.taps import Tap
+
+SIMULATED_PERIPHERAL_ID = 100
+
+if __name__ == "__main__":
+    uri = sys.argv[1] if len(sys.argv) > 1 else "127.0.0.1:647"
+    device = syn.Device(uri)
+    info = device.info()
+    assert info is not None, "Couldn't get device info"
+
+    print("Device info:")
+    print(info)
+
+    channels = [
+        syn.Channel(
+            id=channel_num,
+            electrode_id=channel_num * 2,
+            reference_id=channel_num * 2 + 1,
+        )
+        for channel_num in range(32)
+    ]
+
+    broadband = syn.BroadbandSource(
+        # Use the simulated peripheral (100), or replace with your own
+        peripheral_id=SIMULATED_PERIPHERAL_ID,
+        sample_rate_hz=30000,
+        bit_width=12,
+        gain=20.0,
+        signal=syn.SignalConfig(
+            electrode=syn.ElectrodeConfig(
+                channels=channels,
+                low_cutoff_hz=500.0,
+                high_cutoff_hz=6000.0,
+            )
+        ),
+    )
+
+    config = syn.Config()
+    config.add_node(broadband)
+
+    device.configure(config)
+    device.start()
+
+    info = device.info()
+    assert info is not None, "Couldn't get device info"
+    print("Configured device info:")
+    print(info)
+
+    # stream with tap api
+    tap_client = Tap(uri)
+    tap_client.connect("broadband_source_sim")
+
+    should_run = True
+    total_bytes_read = 0
+    start_time = time.time()
+    last_update_time = start_time
+    update_interval_sec = 1
+    while should_run:
+        try:
+            # Wait for data
+            syn_data = tap_client.read()
+            bytes_read = len(syn_data)
+            if syn_data is None or bytes_read == 0:
+                print("Failed to read data from node")
+                continue
+            # Do something with the data
+            total_bytes_read += bytes_read
+
+            current_time = time.time()
+            if (current_time - last_update_time) >= update_interval_sec:
+                sys.stdout.write("\r")
+                sys.stdout.write(
+                    f"{total_bytes_read} bytes in {time.time() - start_time:.2f} sec"
+                )
+                last_update_time = current_time
+
+            if current_time - start_time > 5:
+                should_run = False
+
+        except KeyboardInterrupt:
+            print("Keyboard interrupt detected, stopping")
+            should_run = False
+
+    print("Stopping device")
+    device.stop()
+

--- a/synapse/server/nodes/base.py
+++ b/synapse/server/nodes/base.py
@@ -71,3 +71,6 @@ class BaseNode(object):
             bind=f"{self.socket[0]}:{self.socket[1]}",
             type=self.type,
         )
+
+    def tap_connections(self):
+        return []

--- a/synapse/server/rpc.py
+++ b/synapse/server/rpc.py
@@ -70,6 +70,7 @@ class SynapseServicer(SynapseDeviceServicer):
     def __init__(self, name, serial, iface_ip, node_object_map, peripherals):
         self.name = name
         self.serial = serial
+        self.iface_ip = iface_ip
         self.node_object_map = node_object_map
         self.peripherals = peripherals
         self.logger = logging.getLogger("server")
@@ -326,7 +327,7 @@ class SynapseServicer(SynapseDeviceServicer):
                 "Creating %s node(%d)" % (NodeType.Name(node.type), node.id)
             )
             node = self.node_object_map[node.type](node.id)
-            if node.type in [NodeType.kStreamIn]:
+            if node.type in [NodeType.kStreamIn, NodeType.kBroadbandSource]:
                 node.configure_iface_ip(self.iface_ip)
 
             status = node.configure(config)

--- a/synapse/server/rpc.py
+++ b/synapse/server/rpc.py
@@ -9,6 +9,7 @@ import grpc
 from synapse.api.node_pb2 import NodeConnection, NodeType
 from synapse.api.logging_pb2 import LogLevel, LogQueryResponse
 from synapse.api.query_pb2 import QueryResponse
+from synapse.api.tap_pb2 import ListTapsResponse
 from synapse.api.status_pb2 import DeviceState, Status, StatusCode
 from synapse.api.device_pb2 import DeviceConfiguration, DeviceInfo
 from synapse.api.synapse_pb2_grpc import (
@@ -168,6 +169,10 @@ class SynapseServicer(SynapseDeviceServicer):
 
         # handle query
 
+        taps = []
+        for node in self.nodes:
+            taps.extend(node.tap_connections())
+
         return QueryResponse(
             data=[1, 2, 3, 4, 5],
             status=Status(
@@ -176,6 +181,7 @@ class SynapseServicer(SynapseDeviceServicer):
                 sockets=self._sockets_status_info(),
                 state=self.state,
             ),
+            list_taps_response=ListTapsResponse(taps=taps),
         )
 
     async def GetLogs(self, request, context):

--- a/synapse/simulator/nodes/broadband_source.py
+++ b/synapse/simulator/nodes/broadband_source.py
@@ -2,9 +2,12 @@ import asyncio
 import random
 import time
 
+import zmq
+
 from synapse.api.node_pb2 import NodeType
 from synapse.api.nodes.broadband_source_pb2 import BroadbandSourceConfig
 from synapse.server.nodes.base import BaseNode
+from synapse.api.tap_pb2 import TapConnection, TapType
 from synapse.server.status import Status
 from synapse.utils.ndtp_types import ElectricalBroadbandData
 
@@ -16,6 +19,9 @@ class BroadbandSource(BaseNode):
     def __init__(self, id):
         super().__init__(id, NodeType.kBroadbandSource)
         self.__config: BroadbandSourceConfig = None
+        self.context = None
+        self.zmq_socket = None
+        self.seq_number = 0
 
     def config(self):
         c = super().config()
@@ -39,15 +45,20 @@ class BroadbandSource(BaseNode):
         if not c.HasField("signal") or not c.signal:
             self.logger.error("node signal not configured")
             return
-        
+
         if not c.signal.HasField("electrode") or not c.signal.electrode:
             self.logger.error("node signal electrode not configured")
             return
-        
+
         e = c.signal.electrode
         if not e.channels:
             self.logger.error("node signal electrode channels not configured")
             return
+
+        if not self.context:
+            self.context = zmq.Context()
+            self.zmq_socket = self.context.socket(zmq.PUB)
+            self.zmq_socket.bind(f"tcp://127.0.0.1:5555")
 
         channels = e.channels
         bit_width = c.bit_width if c.bit_width else 4
@@ -56,20 +67,46 @@ class BroadbandSource(BaseNode):
         t_last_ns = time.time_ns()
         while self.running:
             await asyncio.sleep(0.01)
-            
+
             now = time.time_ns()
             elapsed_ns = now - t_last_ns
             n_samples = int(sample_rate_hz * elapsed_ns / 1e9)
-            
             samples = [[ch.id, [r_sample(bit_width) for _ in range(n_samples)]] for ch in channels]
 
-            data = ElectricalBroadbandData(
-                bit_width=bit_width,
-                is_signed=False,
-                sample_rate=sample_rate_hz,
-                t0=t_last_ns,
-                samples=samples
-            )
+            try:
+                data = ElectricalBroadbandData(
+                    bit_width=bit_width,
+                    is_signed=False,
+                    sample_rate=sample_rate_hz,
+                    t0=t_last_ns,
+                    samples=samples
+                )
+                await self.emit_data(data) # for backward compatibility
+                t_last_ns = now
 
-            await self.emit_data(data)
-            t_last_ns = now
+                # send data over tap
+                packets, self.seq_number = data.pack(self.seq_number)
+                for packet in packets:
+                    self.zmq_socket.send(packet)
+            except Exception as e:
+                print(f"Error sending data: {e}")
+
+    def stop(self):
+        status = super().stop()
+        if not status.ok():
+            return status
+        if self.zmq_socket:
+            self.zmq_socket.close()
+        if self.context:
+            self.context.destroy()
+        return Status()
+
+    def tap_connections(self):
+        return [
+            TapConnection(
+                name="broadband_source_sim",
+                endpoint="tcp://127.0.0.1:5555",
+                    message_type="synapse.utils.ndtp_types.ElectricalBroadbandData",
+                    tap_type=TapType.TAP_TYPE_PRODUCER,
+                )
+        ]

--- a/synapse/simulator/nodes/broadband_source.py
+++ b/synapse/simulator/nodes/broadband_source.py
@@ -24,6 +24,7 @@ class BroadbandSource(BaseNode):
         self.zmq_socket = None
         self.seq_number = 0
         self.iface_ip = None
+        self.port = None
 
     def config(self):
         c = super().config()
@@ -58,6 +59,10 @@ class BroadbandSource(BaseNode):
             return
 
         if not self.zmq_context:
+            if not self.iface_ip:
+                self.logger.error("iface_ip not configured")
+                return
+
             self.zmq_context = zmq.Context()
             self.zmq_socket = self.zmq_context.socket(zmq.PUB)
             self.port = self.zmq_socket.bind_to_random_port(f"tcp://{self.iface_ip}")
@@ -96,9 +101,9 @@ class BroadbandSource(BaseNode):
                     )
                     try:
                         self.zmq_socket.send(frame.SerializeToString())
-                        self.seq_number = (self.seq_number + 1) % 2**16
+                        self.seq_number += 1
                     except Exception as e:
-                        print(f"Error sending data: {e}")
+                        self.logger.error(f"Error sending data: {e}")
 
                 t_last_ns = now
             except Exception as e:


### PR DESCRIPTION
# Summary
This is a change for #125. I wasn't sure if there's another simulated/virtual SciFi device that I should write the example against so I went ahead and updated the simulated broadband source in this repo to stream data over tap API. Also migrates legacy ndtp type to BroadbandFrame.

# Testing
## Run simulated device
```
synapse-sim --iface-ip 127.0.0.1
```

## Run Client
1. script
```
python synapse/examples/tap_example.py
```

2. CLI
```
➜  synapsectl discover
          ⠼ Discovering Synapse devices... Found 1 so far (⌘C to stop)
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Name                                       ┃                            Host ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ vague-strange-oryx                         │                   192.168.29.38 │
└────────────────────────────────────────────┴─────────────────────────────────┘

➜  synapsectl -u 192.168.29.38 info
Name: vague-strange-oryx
Status: Stopped
Serial: SFI000001
Synapse Version: 2097152
Firmware Version: 1
Peripherals
└── No peripherals found
None

➜  synapsectl -u 127.0.0.1 configure device_config.json
Device configured

➜  synapsectl -u 127.0.0.1 start
Device started

➜  synapsectl -u 127.0.0.1 read device_config.json --list-taps
[08:06:14] Connected to vague-strange-oryx                                        streaming.py:895

Available Taps:
==================================================
Name: broadband_source_sim ✓ SUPPORTED
Type: synapse.BroadbandFrame
Endpoint: tcp://127.0.0.1:5555
------------------------------

Total: 1 taps found, 1 supported

➜  synapsectl -u 127.0.0.1 read device_config.json --tap-name broadband_source_sim
[08:06:33] Connected to vague-strange-oryx                                        streaming.py:895
[08:06:34] Device is already running, reading from existing tap                   streaming.py:583
           Looking for specified tap: broadband_source_sim                        streaming.py:713
           Found specified tap: broadband_source_sim (type:                       streaming.py:716
           synapse.BroadbandFrame)
[07/17/25 08:06:34] INFO     INFO:synapse.client.taps:Connecting to tap...             taps.py:119
           Detecting stream parameters from first message...                      streaming.py:675
           Detected sample rate: 30000 Hz                                         streaming.py:695
           Detected 32 channels (0-31)                                            streaming.py:696
Starting data streaming... (Ctrl+C to stop)
[07/17/25 08:06:36] INFO     INFO:synapse.client.taps:Stream interrupted               taps.py:264
Messages: 77,816 (31737.1/s) Dropped: -65,536 Queue Drops: 0 Loss: -533.68% Runtime: 2.6s
Total streaming time: 2.7 seconds
[08:06:36] Stopping device...                                                     streaming.py:969
           Device stopped successfully