### PR TITLE
update optical stim node to latest

### DIFF
--- a/synapse/client/nodes/optical_stimulation.py
+++ b/synapse/client/nodes/optical_stimulation.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, List
 from synapse.api.node_pb2 import NodeConfig, NodeType
 from synapse.api.nodes.optical_stimulation_pb2 import OpticalStimulationConfig
 from synapse.client.node import Node
@@ -8,40 +8,40 @@ class OpticalStimulation(Node):
     type = NodeType.kOpticalStimulation
 
     def __init__(
-        self, peripheral_id, pixel_mask, bit_width, sample_rate, gain
+        self, peripheral_id: int, pixel_mask: List[int], bit_width: int, frame_rate: int, gain: float, send_receipts: bool = False
     ):
         self.pixel_mask = pixel_mask
         self.peripheral_id = peripheral_id
         self.bit_width = bit_width
-        self.sample_rate = sample_rate
+        self.frame_rate = frame_rate
         self.gain = gain
+        self.send_receipts = send_receipts
 
     def _to_proto(self):
         n = NodeConfig()
         p = OpticalStimulationConfig()
         p.peripheral_id = self.peripheral_id
-        for i in self.pixel_mask.iter_channels():
-            p.pixel_mask.append(i)
+        p.pixel_mask.extend(self.pixel_mask)
         p.bit_width = self.bit_width
-        p.sample_rate = self.sample_rate
+        p.frame_rate = self.frame_rate
         p.gain = self.gain
-
+        p.send_receipts = self.send_receipts
         n.optical_stimulation.CopyFrom(p)
         return n
 
     @staticmethod
     def _from_proto(proto: Optional[OpticalStimulationConfig]):
         if proto is None:
-            return OpticalStimulation()
+            return OpticalStimulation(0, [], 0, 0, 0.0, False)
 
         if not isinstance(proto, OpticalStimulationConfig):
             raise ValueError("proto is not of type OpticalStimulationConfig")
 
-        new_node = OpticalStimulation(
+        return OpticalStimulation(
             peripheral_id=proto.peripheral_id,
-            pixel_mask=proto.pixel_mask,
+            pixel_mask=list(proto.pixel_mask),
             bit_width=proto.bit_width,
-            sample_rate=proto.sample_rate,
+            frame_rate=proto.frame_rate,
             gain=proto.gain,
+            send_receipts=proto.send_receipts
         )
-        return new_node


### PR DESCRIPTION
# Summary

Allows for handling of pixel16k / optical stimulation node device configurations. E.g.:

```
{
  "nodes": [
    {
      "type": "kOpticalStimulation",
      "id": 1,
      "optical_stimulation": {
        "peripheral_id": 3,
        "pixel_mask": [],
        "bit_width": 8,
        "frame_rate": 1,
        "gain": 1.0,
        "send_receipts": false
      }
    }
  ],
  "connections": []
}
```