### PR TITLE
fix: configure iface ip for local test

### DIFF
--- a/synapse/tests/simulator/test_broadband_source.py
+++ b/synapse/tests/simulator/test_broadband_source.py
@@ -6,10 +6,11 @@ from synapse.api.nodes.signal_config_pb2 import SignalConfig, ElectrodeConfig
 from synapse.api.channel_pb2 import Channel
 from synapse.utils.ndtp_types import ElectricalBroadbandData
 
+
 @pytest.mark.asyncio
 async def test_broadband_source_data_generation():
     node = BroadbandSource(id=1)
-    
+
     config = BroadbandSourceConfig(
         peripheral_id=1,
         bit_width=12,
@@ -19,15 +20,16 @@ async def test_broadband_source_data_generation():
             electrode=ElectrodeConfig(
                 channels=[
                     Channel(id=1, electrode_id=2, reference_id=3),
-                    Channel(id=2, electrode_id=3, reference_id=4)
+                    Channel(id=2, electrode_id=3, reference_id=4),
                 ],
                 low_cutoff_hz=500.0,
-                high_cutoff_hz=6000.0
+                high_cutoff_hz=6000.0,
             )
-        )
+        ),
     )
-    
+
     status = node.configure(config)
+    node.configure_iface_ip("127.0.0.1")
     assert status.ok()
 
     data_received = []
@@ -35,40 +37,38 @@ async def test_broadband_source_data_generation():
     async def collect_data(_, data):
         data_received.append(data)
 
-    node.add_downstream_node(type('', (), {'on_data_received': collect_data})())
-    
+    node.add_downstream_node(type("", (), {"on_data_received": collect_data})())
+
     status = node.start()
     assert status.ok()
-    
+
     await asyncio.sleep(1)
-    
-    status = node.stop() 
+
+    status = node.stop()
     assert status.ok()
 
     assert len(data_received) > 0
-    
+
     first_packet = data_received[0]
     assert isinstance(first_packet, ElectricalBroadbandData)
     assert first_packet.bit_width == 12
     assert first_packet.sample_rate == 30000
     assert not first_packet.is_signed
     assert len(first_packet.samples) == 2
-    
+
     for channel_id, samples in first_packet.samples:
         assert channel_id in [1, 2]
         for sample in samples:
             assert 0 <= sample < 2**12
 
+
 def test_broadband_source_invalid_config():
     node = BroadbandSource(id=1)
-    
+
     config = BroadbandSourceConfig(
-        peripheral_id=1,
-        bit_width=12,
-        sample_rate_hz=30000,
-        gain=20.0
+        peripheral_id=1, bit_width=12, sample_rate_hz=30000, gain=20.0
     )
-    
+
     status = node.configure(config)
     assert status.ok()
     assert not node.running
@@ -79,14 +79,10 @@ def test_broadband_source_invalid_config():
         sample_rate_hz=30000,
         gain=20.0,
         signal=SignalConfig(
-            electrode=ElectrodeConfig(
-                low_cutoff_hz=500.0,
-                high_cutoff_hz=6000.0
-            )
-        )
+            electrode=ElectrodeConfig(low_cutoff_hz=500.0, high_cutoff_hz=6000.0)
+        ),
     )
-    
+
     status = node.configure(config)
     assert status.ok()
     assert not node.running
-


### PR DESCRIPTION
# Summary
Missing a configuration for iface ip for one of the tests, causing the tests to fail