### PR TITLE
Fix: synapsectl deploy issues with dependency `rich`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ pyzmq
 build
 scipy
 cython
-rich
+rich==14.0.0
 pre-commit
 pytest
 pytest-asyncio


### PR DESCRIPTION
# Summary
Running `foo@bar: synapsectl -u "your-device-identifier" deploy ${REPO_ROOT}` would throw a mysterious error:
```
(synapse-python) foo@bar:~/path/to/synapse-example-app$ synapsectl -v -u "sunfish" deploy .
Deploying application: synapse-example-app
Building application: synapse-example-app...
Binary already exists at: /path/to/synapse-example-app/build/aarch64/synapse-example-app (skipping rebuild) 
Extracting SDK libraries from Docker image synapse-example-app:latest-amd64...
Packaging App for Synapse Device (Docker image: cdrx/fpm-ubuntu:latest) ...
Package created successfully!
[15:11:18]  Uncaught error during function. Why: pop from empty list                                                                                     __main__.py:96
usage: synapsectl [-h] [--uri URI] [--version] [--verbose]
                  {discover,info,query,start,stop,configure,logs,read,plot,file,taps,deploy,build,settings} ...

Synapse Device Manager

options:
  -h, --help            show this help message and exit
  --uri URI, -u URI     The device identifier to connect to. Can either be the IP address or name
  --version             show program's version number and exit
  --verbose, -v         Enable verbose output

Commands:
  {discover,info,query,start,stop,configure,logs,read,plot,file,taps,deploy,build,settings}
    discover            Discover Synapse devices on the network
    info                Get device information
    query               Execute a query on the device
    start               Start the device or an application
    stop                Stop the device or an application
    configure           Write a configuration to the device
    logs                Get logs from the device
    read                Read from a device's Broadband Tap and save to HDF5
    plot                Plot recorded synapse data
    file                File commands
    taps                Interact with taps on the network
    deploy              Deploy an application to a Synapse device
    build               Cross-compile and package an application into a .deb without deploying
    settings            Manage the persistent device settings

```
The issue was introduced in the `rich` dependency as specified here: https://github.com/Textualize/rich/issues/3809

# Changes
* Pinned the dependency `rich` in `requirements.txt` to version 14.0.0.

# Testing
Verified that the command `foo@bar: synapsectl -u "your-device-identifier" deploy ${REPO_ROOT}` works correctly with version 14.0.0 of `rich`.