### PR TITLE
Feature: More verbose error messages for synapsectl configure

### DIFF
--- a/synapse/utils/proto.py
+++ b/synapse/utils/proto.py
@@ -1,4 +1,4 @@
-from google.protobuf.json_format import Parse
+from google.protobuf.json_format import Parse, ParseError
 from synapse.api.device_pb2 import DeviceConfiguration
 from synapse.api.app_pb2 import AppManifest
 import synapse as syn
@@ -8,20 +8,35 @@ def load_device_config(path_to_json, console):
     # We support either a manifest or a device configuration.
     # First, try to load a device configuration
     try:
-        json_text = open(path_to_json, "r").read()
+        with open(path_to_json, "r") as f:
+            json_text = f.read()
+    except FileNotFoundError:
+        raise ValueError(f"File not found: {path_to_json}")
+    except PermissionError:
+        raise ValueError(f"Permission denied reading: {path_to_json}")
+    except Exception as e:
+        raise ValueError(f"Failed to read {path_to_json}: {e}")
+
+    errors = []
+    try:
         cfg_proto = Parse(json_text, DeviceConfiguration())
         return syn.Config.from_proto(cfg_proto)
-    except Exception:
-        pass
+    except ParseError as e:
+        errors.append(f"DeviceConfiguration: {str(e)}")
+    except Exception as e:
+        errors.append(f"DeviceConfiguration: {type(e).__name__}: {str(e)}")
 
     # We couldn't load a device configuration, so try to load a manifest
     try:
         json_text = open(path_to_json, "r").read()
         manifest_proto = Parse(json_text, AppManifest())
         return syn.Config.from_proto(manifest_proto.device_config)
+    except ParseError as e:
+        errors.append(f"AppManifest: {str(e)}")
     except Exception:
-        raise ValueError(
-            f"Could not parse {path_to_json} as either device configuration or manifest"
-        )
+        errors.append(f"AppManifest: {type(e).__name__}: {str(e)}")
 
-    return None
+    # Only reached here when we've failed to parse
+    error_msg = f"Could not parse {path_to_json} as either format:\n"
+    error_msg += "\n".join(f"  - {error}" for error in errors)
+    raise ValueError(error_msg)


### PR DESCRIPTION
# Summary 
Added error messages for the following cases when using `synapsectl -u foo configure` and `synapsectl -u foo start`:
- Config JSON file not found
- Config JSON no read permissions
- file.read() generic exception message
and more importantly:
- catching the exceptions informing about syntax errors in the config JSON file thrown by google.protobuf.json_format.Parse

# Motivation
Previously, every single error in the configuration process would simply give this error message:
```
Uncaught error during function. Why: Could not parse ../app-name/config.json as either device configuration or manifest
```
This would be the case even if the file was not found, which was not informative if they typo'd the filename. The message would also be not informative if they did not have read permissions for the file. It now prints an informative error message for these cases.

The syntax error messages though is especially helpful, as it'll inform users on how to debug where syntax errors occur in their config. Now, it will print something along the lines of (Case: forgot ending quote):
```
[15:26:46]  Uncaught error during function. Why: Could not parse ../synapse-spike-detect/config/simulator.json as either format:                        __main__.py:96
             - DeviceConfiguration: Failed to load JSON: Expecting property name enclosed in double quotes: line 14 column 5 (char 257).                              
             - AppManifest: Failed to load JSON: Expecting property name enclosed in double quotes: line 14 column 5 (char 257).  
```
or something like (Case: forgot to put value in field)
```
[15:28:34]  Uncaught error during function. Why: Could not parse ../synapse-spike-detect/config/simulator.json as either format:                        __main__.py:96
             - DeviceConfiguration: Failed to load JSON: Expecting value: line 9 column 28 (char 180).                                                                
             - AppManifest: Failed to load JSON: Expecting value: line 9 column 28 (char 180).  
```
or even incompatibilities with Synapse API (Case: typo'd enum value w.r.t. Synapse API):
```
[15:29:00]  Uncaught error during function. Why: Could not parse ../synapse-spike-detect/config/simulator.json as either format:                        __main__.py:96
             - DeviceConfiguration: Failed to parse nodes field: Failed to parse type field: Invalid enum value kApplicationasdfasf for enum type                     
           synapse.NodeType at DeviceConfiguration.nodes[0].type..                                                                                                    
             - AppManifest: Message type "synapse.AppManifest" has no field named "nodes" at "AppManifest".                                                           
            Available Fields(except extensions): "['name', 'configSchema', 'deviceConfig']"  
```
