### PR TITLE
Fix: bugs in simulator config, discovery, and broadband source

### DIFF
--- a/synapse/client/config.py
+++ b/synapse/client/config.py
@@ -4,11 +4,9 @@ from synapse.client.nodes import NODE_TYPE_OBJECT_MAP
 
 
 class Config(object):
-    nodes = []
-    connections = []
-
     def __init__(self):
-        pass
+        self.nodes = []
+        self.connections = []
 
     def _gen_node_id(self):
         return len(self.nodes) + 1

--- a/synapse/server/entrypoint.py
+++ b/synapse/server/entrypoint.py
@@ -63,6 +63,13 @@ def main(
     )
     args = parser.parse_args()
 
+    # if these contain spaces, the discovery will fail because the broadcast
+    # packet is parsed with str.split() in discover.py and each space marks a new token
+    if " " in args.name:
+        parser.error("--name must not contain spaces")
+    if " " in args.serial:
+        parser.error("--serial must not contain spaces")
+
     init_logging(level=logging.DEBUG if args.verbose else logging.INFO)
 
     # verify that network interface is real

--- a/synapse/simulator/nodes/broadband_source.py
+++ b/synapse/simulator/nodes/broadband_source.py
@@ -78,6 +78,9 @@ class BroadbandSource(BaseNode):
             now = time.time_ns()
             elapsed_ns = now - t_last_ns
             n_samples = int(sample_rate_hz * elapsed_ns / 1e9)
+            if n_samples == 0:
+                continue
+
             samples = [[ch.id, [r_sample(bit_width) for _ in range(n_samples)]] for ch in channels]
 
             try:
@@ -105,7 +108,7 @@ class BroadbandSource(BaseNode):
                     except Exception as e:
                         self.logger.error(f"Error sending data: {e}")
 
-                t_last_ns = now
+                t_last_ns += int(n_samples * 1e9 / sample_rate_hz)
             except Exception as e:
                 print(f"Error sending data: {e}")
 


### PR DESCRIPTION
Hey! I was tinkering with the Synapse CLI and found/fixed a few bugs along the way. Here they are, in the same order as the diff shows the files changed:

1. `Config` class stored `nodes` and `connections` on the class rather than the instance/object. This meant every instance of `Config()` would share same values for those two properties, which causes problems if you have multiple `Config()`s
2. The simulator would let you configure a name with a space inside it, which would cause the client to be unable to discover the device. This is because spaces are used to separate values inside of [synapse-python/synapse/utils/discover.py](https://github.com/sciencecorp/synapse-python/blob/78138434197482ddf1b6b447f8bce1a7a1137911/synapse/utils/discover.py#L41), and so shouldn't appear in any given value.
3. The broadband source dropped lots of frames if you ran it below 100hz, because of how `n_samples` was calculated