### PR TITLE
Bump synapse-api submodule to 2.4.1 (impedance peripheral_id)

### DIFF
--- a/synapse/_api_version.py
+++ b/synapse/_api_version.py
@@ -1,2 +1,2 @@
 # Generated from synapse-api/VERSION by setup.py. Do not edit.
-SYNAPSE_API_VERSION = "2.4.0"
+SYNAPSE_API_VERSION = "2.4.1"


### PR DESCRIPTION
Picks up the new ImpedanceQuery.peripheral_id field. Clients constructing impedance queries can now set the field in their JSON configs (synapsectl reads it automatically via proto3 JSON parsing).

Refreshes synapse/_api_version.py to match the new VERSION (2.4.1).