### PR TITLE
chore: bump version 2.7.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ stamp_api_version()
 
 setup(
     name="science-synapse",
-    version="2.7.1",
+    version="2.7.2",
     description="Client library and CLI for the Synapse API",
     author="Science Team",
     author_email="team@science.xyz",


### PR DESCRIPTION
Git release tagged v2.7.1 was pinned to the incorrect synapse-api commit locally, so bumping to redeploy fresh release