### PR TITLE
fix(release): skip-existing on testpypi and longer wait before validate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,13 +52,14 @@ jobs:
         with:
           repository-url: https://test.pypi.org/legacy/
           verbose: true
+          skip-existing: true
 
   validate-test-pypi-release:
     runs-on: ubuntu-latest
     needs: publish-testpypi
     steps:
       - name: wait for package to be available
-        run: sleep 60
+        run: sleep 180
 
       - name: install test pypi release
         run: |


### PR DESCRIPTION
testpypi publish failed with a 400 when the version was already present on testpypi, blocking the downstream validate and pypi publish jobs. skip-existing makes the upload idempotent, and the wait before validating is bumped 60s -> 180s to give testpypi more time to index the new release.