### PR TITLE
fix: apps build SDK .so isolation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,9 @@ instance/
 # Sphinx documentation
 docs/_build/
 
+# Superpowers planning docs (specs/plans) — kept local, not committed
+docs/superpowers/
+
 # PyBuilder
 .pybuilder/
 target/

--- a/synapse/cli/build.py
+++ b/synapse/cli/build.py
@@ -270,6 +270,25 @@ def build_app(
     return False
 
 
+def _app_lib_parts(app_name: str) -> list[str]:
+    """Path segments for an app's private library directory.
+
+    Single source of truth shared by the on-device path and the host staging
+    path so the two can never drift apart.
+    """
+    return ["opt", "scifi", "apps", app_name, "lib"]
+
+
+def app_lib_device_path(app_name: str) -> str:
+    """Absolute on-device path to *app_name*'s private lib dir (forward slashes)."""
+    return "/" + "/".join(_app_lib_parts(app_name))
+
+
+def app_lib_staging_dir(staging_dir: str, app_name: str) -> str:
+    """Host staging path that maps to the app's private lib dir inside the .deb."""
+    return os.path.join(staging_dir, *_app_lib_parts(app_name))
+
+
 def build_deb_package(app_dir: str, app_name: str, version: str = "0.1.0") -> bool:
     """Stage *app_name* and produce a ``.deb`` file within *app_dir*."""
 

--- a/synapse/cli/build.py
+++ b/synapse/cli/build.py
@@ -337,27 +337,7 @@ def build_deb_package(app_dir: str, app_name: str, version: str = "0.1.0") -> bo
         os.makedirs(bin_dst_dir, exist_ok=True)
         shutil.copy2(binary_path, os.path.join(bin_dst_dir, app_name))
 
-        svc_content = f"""[Unit]
-Description=Synapse Application
-After=network-online.target
-Wants=network-online.target
-Requires=systemd-udevd.service
-After=systemd-udevd.service
-
-[Service]
-Type=simple
-User=root
-Restart=no
-ExecStartPre=/sbin/sysctl -w net.core.wmem_max=4194304
-ExecStartPre=/sbin/sysctl -w net.core.wmem_default=4194304
-Environment=LD_LIBRARY_PATH=/opt/scifi/usr-libs:/opt/scifi/lib
-Environment=SCIFI_ROOT=/opt/scifi
-ExecStart=/opt/scifi/bin/{app_name}
-WorkingDirectory=/opt/scifi
-
-[Install]
-WantedBy=multi-user.target
-"""
+        svc_content = render_service_unit(app_name)
         svc_dst = os.path.join(
             staging_dir, "etc", "systemd", "system", f"{app_name}.service"
         )
@@ -387,7 +367,7 @@ WantedBy=multi-user.target
         os.chmod(postremove_path, 0o755)
         lifecycle_scripts_tmp.append(postremove_path)
 
-        lib_dst_dir = os.path.join(staging_dir, "opt", "scifi", "lib")
+        lib_dst_dir = app_lib_staging_dir(staging_dir, app_name)
         os.makedirs(lib_dst_dir, exist_ok=True)
 
         # QNN libraries are dlopen'd from /usr/lib/ (hardcoded paths in SDK),

--- a/synapse/cli/build.py
+++ b/synapse/cli/build.py
@@ -289,6 +289,37 @@ def app_lib_staging_dir(staging_dir: str, app_name: str) -> str:
     return os.path.join(staging_dir, *_app_lib_parts(app_name))
 
 
+def render_service_unit(app_name: str) -> str:
+    """Render the systemd unit text for *app_name*.
+
+    The app's private lib dir is placed first on LD_LIBRARY_PATH so the app loads
+    the exact synapse-app-sdk (and other bundled libs) it was built against, ahead
+    of the shared /opt/scifi/lib fallback.
+    """
+    app_lib = app_lib_device_path(app_name)
+    return f"""[Unit]
+Description=Synapse Application
+After=network-online.target
+Wants=network-online.target
+Requires=systemd-udevd.service
+After=systemd-udevd.service
+
+[Service]
+Type=simple
+User=root
+Restart=no
+ExecStartPre=/sbin/sysctl -w net.core.wmem_max=4194304
+ExecStartPre=/sbin/sysctl -w net.core.wmem_default=4194304
+Environment=LD_LIBRARY_PATH={app_lib}:/opt/scifi/usr-libs:/opt/scifi/lib
+Environment=SCIFI_ROOT=/opt/scifi
+ExecStart=/opt/scifi/bin/{app_name}
+WorkingDirectory=/opt/scifi
+
+[Install]
+WantedBy=multi-user.target
+"""
+
+
 def build_deb_package(app_dir: str, app_name: str, version: str = "0.1.0") -> bool:
     """Stage *app_name* and produce a ``.deb`` file within *app_dir*."""
 

--- a/synapse/tests/cli/test_build.py
+++ b/synapse/tests/cli/test_build.py
@@ -23,3 +23,30 @@ def test_app_lib_staging_dir_is_not_the_shared_lib_dir():
     staging = "/tmp/stg"
     shared = os.path.join(staging, "opt", "scifi", "lib")
     assert app_lib_staging_dir(staging, "myapp") != shared
+
+
+from synapse.cli.build import render_service_unit
+
+
+def test_service_unit_puts_app_lib_dir_first_on_ld_library_path():
+    unit = render_service_unit("myapp")
+    assert (
+        "Environment=LD_LIBRARY_PATH="
+        "/opt/scifi/apps/myapp/lib:/opt/scifi/usr-libs:/opt/scifi/lib" in unit
+    )
+
+
+def test_service_unit_execstart_points_at_app_binary():
+    unit = render_service_unit("myapp")
+    assert "ExecStart=/opt/scifi/bin/myapp" in unit
+
+
+def test_service_unit_keeps_sysctl_execstartpre_hooks():
+    unit = render_service_unit("myapp")
+    assert "ExecStartPre=/sbin/sysctl -w net.core.wmem_max=4194304" in unit
+    assert "ExecStartPre=/sbin/sysctl -w net.core.wmem_default=4194304" in unit
+
+
+def test_service_unit_ld_path_matches_device_path_helper():
+    unit = render_service_unit("synapse-example-app")
+    assert app_lib_device_path("synapse-example-app") + ":" in unit

--- a/synapse/tests/cli/test_build.py
+++ b/synapse/tests/cli/test_build.py
@@ -1,6 +1,15 @@
 import os
 
-from synapse.cli.build import app_lib_device_path, app_lib_staging_dir
+from synapse.cli.build import (
+    _app_lib_parts,
+    app_lib_device_path,
+    app_lib_staging_dir,
+    render_service_unit,
+)
+
+
+def test_app_lib_parts_returns_expected_segments():
+    assert _app_lib_parts("myapp") == ["opt", "scifi", "apps", "myapp", "lib"]
 
 
 def test_app_lib_device_path_is_absolute_forward_slash():
@@ -19,13 +28,13 @@ def test_app_lib_staging_dir_joins_under_staging_root():
     assert app_lib_staging_dir(staging, "myapp") == expected
 
 
-def test_app_lib_staging_dir_is_not_the_shared_lib_dir():
+def test_app_lib_staging_dir_is_per_app_not_shared_lib_dir():
     staging = "/tmp/stg"
-    shared = os.path.join(staging, "opt", "scifi", "lib")
-    assert app_lib_staging_dir(staging, "myapp") != shared
-
-
-from synapse.cli.build import render_service_unit
+    result = app_lib_staging_dir(staging, "myapp")
+    # Positive: it is the per-app dir...
+    assert result == os.path.join(staging, "opt", "scifi", "apps", "myapp", "lib")
+    # ...and negative: it is NOT the old shared /opt/scifi/lib path.
+    assert result != os.path.join(staging, "opt", "scifi", "lib")
 
 
 def test_service_unit_puts_app_lib_dir_first_on_ld_library_path():

--- a/synapse/tests/cli/test_build.py
+++ b/synapse/tests/cli/test_build.py
@@ -1,0 +1,25 @@
+import os
+
+from synapse.cli.build import app_lib_device_path, app_lib_staging_dir
+
+
+def test_app_lib_device_path_is_absolute_forward_slash():
+    assert app_lib_device_path("myapp") == "/opt/scifi/apps/myapp/lib"
+
+
+def test_app_lib_device_path_uses_app_name():
+    assert app_lib_device_path("synapse-example-app") == (
+        "/opt/scifi/apps/synapse-example-app/lib"
+    )
+
+
+def test_app_lib_staging_dir_joins_under_staging_root():
+    staging = "/tmp/synapse-package-xyz"
+    expected = os.path.join(staging, "opt", "scifi", "apps", "myapp", "lib")
+    assert app_lib_staging_dir(staging, "myapp") == expected
+
+
+def test_app_lib_staging_dir_is_not_the_shared_lib_dir():
+    staging = "/tmp/stg"
+    shared = os.path.join(staging, "opt", "scifi", "lib")
+    assert app_lib_staging_dir(staging, "myapp") != shared


### PR DESCRIPTION
# Summary
The resulting .deb package from `synapsectl apps build` now places the SDK shared library into a directory that is "namespaced" with the app. This way, apps built under different versions of the SDK can both work on the target device, as previously, the symlink to the SDK would stay put to the first version deployed onto the device. This also avoids DEB package ownership issues over the SDK.